### PR TITLE
Add error message and self-help instructions for kubernetes permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,21 +324,40 @@ python3 xpk.py cluster create --cluster-cpu-machine-type=CPU_TYPE ...
 
 ## Permission Issues: `requires one of ["permission_name"] permission(s)`.
 
-Check the permissions for users on your project. Go to [iam-admin](https://console.cloud.google.com/iam-admin/) or use gcloud cli:
+1) Determine the role needed based on the permission error:
 
-```shell
-CURRENT_GKE_USER=$(gcloud config get account)
-PROJECT_ID=my-project-id
-gcloud projects get-iam-policy $PROJECT_ID --filter="bindings.members:$CURRENT_GKE_USER" --flatten="bindings[].members"
-```
+    ```shell
+    # For example: `requires one of ["container.*"] permission(s)`
+    # Add [Kubernetes Engine Admin](https://cloud.google.com/iam/docs/understanding-roles#kubernetes-engine-roles) to your user.
+    ```
 
-Add a role for user on your project. Go to [iam-admin](https://console.cloud.google.com/iam-admin/) or use gcloud cli:
-```
-PROJECT_ID=my-project-id
-CURRENT_GKE_USER=$(gcloud config get account)
-ROLE=my-role-needed
-gcloud projects add-iam-policy-binding $PROJECT_ID --member user:$CURRENT_GKE_USER --role=$ROLE
-```
+2) Add the role to the user in your project.
+
+    Go to [iam-admin](https://console.cloud.google.com/iam-admin/) or use gcloud cli:
+    ```shell
+    PROJECT_ID=my-project-id
+    CURRENT_GKE_USER=$(gcloud config get account)
+    ROLE=my-role-needed
+    gcloud projects add-iam-policy-binding $PROJECT_ID --member user:$CURRENT_GKE_USER --role=$ROLE
+    ```
+
+3) Check the permissions are correct for the users.
+
+    Go to [iam-admin](https://console.cloud.google.com/iam-admin/) or use gcloud cli:
+
+    ```shell
+    PROJECT_ID=my-project-id
+    CURRENT_GKE_USER=$(gcloud config get account)
+    gcloud projects get-iam-policy $PROJECT_ID --filter="bindings.members:$CURRENT_GKE_USER" --flatten="bindings[].members"
+    ```
+
+4) Confirm you have logged in locally with the correct user.
+
+    ```shell
+    gcloud auth login
+    ```
+
+
 
 ### Roles needed based on permission errors:
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ python3 xpk.py cluster create --cluster-cpu-machine-type=CPU_TYPE ...
     ```shell
     PROJECT_ID=my-project-id
     CURRENT_GKE_USER=$(gcloud config get account)
-    ROLE=my-role-needed
+    ROLE=roles/container.admin  # container.admin is the role needed for Kubernetes Engine Admin
     gcloud projects add-iam-policy-binding $PROJECT_ID --member user:$CURRENT_GKE_USER --role=$ROLE
     ```
 

--- a/README.md
+++ b/README.md
@@ -321,3 +321,27 @@ gcloud compute machine-types list --zones=$ZONE_LIST
 # Adjust default cpu machine type.
 python3 xpk.py cluster create --cluster-cpu-machine-type=CPU_TYPE ...
 ```
+
+## Permission Issues: `requires one of ["permission_name"] permission(s)`.
+
+Check the permissions for users on your project. Go to [iam-admin](https://console.cloud.google.com/iam-admin/) or use gcloud cli:
+
+```shell
+CURRENT_GKE_USER=$(gcloud config get account)
+PROJECT_ID=my-project-id
+gcloud projects get-iam-policy $PROJECT_ID --filter="bindings.members:$CURRENT_GKE_USER" --flatten="bindings[].members"
+```
+
+Add a role for user on your project. Go to [iam-admin](https://console.cloud.google.com/iam-admin/) or use gcloud cli:
+```
+PROJECT_ID=my-project-id
+CURRENT_GKE_USER=$(gcloud config get account)
+ROLE=my-role-needed
+gcloud projects add-iam-policy-binding $PROJECT_ID --member user:$CURRENT_GKE_USER --role=$ROLE
+```
+
+### Roles needed based on permission errors:
+
+* `requires one of ["container.*"] permission(s)`
+
+  Add [Kubernetes Engine Admin](https://cloud.google.com/iam/docs/understanding-roles#kubernetes-engine-roles) to your user.

--- a/xpk.py
+++ b/xpk.py
@@ -1112,7 +1112,7 @@ def set_jobset_on_cluster(args) -> int:
       ' `PROJECT_ID=my-project-id; CURRENT_GKE_USER=$(gcloud config get account);'
       ' gcloud projects get-iam-policy $PROJECT_ID'
       ' --filter="bindings.members:$CURRENT_GKE_USER"'
-      ' --flatten="bindings[].members"`\n.'
+      ' --flatten="bindings[].members"`.\n'
     )
     return 1
   return 0

--- a/xpk.py
+++ b/xpk.py
@@ -1096,6 +1096,24 @@ def set_jobset_on_cluster(args) -> int:
         'jobset command on server side returned with ERROR returncode'
         f' {return_code}.\n'
     )
+    xpk_print(
+      'This likely means you\'re missing Kubernetes Permissions, you can'
+      ' validate this by checking if the error references permission'
+      ' problems such as `requires one of ["container.*"] permission(s)`.'
+      ' Users fix this permission issue by applying the role '
+      ' `Kubernetes Engine Admin` in https://console.cloud.google.com/iam-admin/'
+      ' Run the following command to add this permission to your current user:\n\n'
+      ' `PROJECT_ID=my-project-id; CURRENT_GKE_USER=$(gcloud config get account);'
+      ' gcloud projects add-iam-policy-binding $PROJECT_ID'
+      ' --member user:$CURRENT_GKE_USER --role=roles/container.admin`\n'
+      ' \nIf you see other missing permissions, please add the correct role to'
+      ' your user. Then remember to `gcloud auth login` and make sure you have'
+      ' the right permissions by running:\n\n'
+      ' `PROJECT_ID=my-project-id; CURRENT_GKE_USER=$(gcloud config get account);'
+      ' gcloud projects get-iam-policy $PROJECT_ID'
+      ' --filter="bindings.members:$CURRENT_GKE_USER"'
+      ' --flatten="bindings[].members"`\n.'
+    )
     return 1
   return 0
 

--- a/xpk.py
+++ b/xpk.py
@@ -1100,19 +1100,8 @@ def set_jobset_on_cluster(args) -> int:
       'This likely means you\'re missing Kubernetes Permissions, you can'
       ' validate this by checking if the error references permission'
       ' problems such as `requires one of ["container.*"] permission(s)`.'
-      ' Users fix this permission issue by applying the role '
-      ' `Kubernetes Engine Admin` in https://console.cloud.google.com/iam-admin/'
-      ' Run the following command to add this permission to your current user:\n\n'
-      ' `PROJECT_ID=my-project-id; CURRENT_GKE_USER=$(gcloud config get account);'
-      ' gcloud projects add-iam-policy-binding $PROJECT_ID'
-      ' --member user:$CURRENT_GKE_USER --role=roles/container.admin`\n'
-      ' \nIf you see other missing permissions, please add the correct role to'
-      ' your user. Then remember to `gcloud auth login` and make sure you have'
-      ' the right permissions by running:\n\n'
-      ' `PROJECT_ID=my-project-id; CURRENT_GKE_USER=$(gcloud config get account);'
-      ' gcloud projects get-iam-policy $PROJECT_ID'
-      ' --filter="bindings.members:$CURRENT_GKE_USER"'
-      ' --flatten="bindings[].members"`.\n'
+      ' Follow our readme: https://github.com/google/xpk/blob/main/README.md#troubleshooting'
+      ' for instructions on how to fix these permissions.'
     )
     return 1
   return 0


### PR DESCRIPTION
## Fixes / Features
- Adds instructions on how to add kubernetes permissions
- Adds error message with cli instructions for adding kubernetes permissions

## Testing / Documentation
Viewed error message:

```
[XPK] This likely means you're missing Kubernetes Permissions, you can validate this by checking if the error references permission problems such as `requires one of ["container.*"] permission(s)`. Users fix this permission issue by applying the role  `Kubernetes Engine Admin` in https://console.cloud.google.com/iam-admin/ Run the following command to add this permission to your current user:

 `PROJECT_ID=my-project-id; CURRENT_GKE_USER=$(gcloud config get account); gcloud projects add-iam-policy-binding $PROJECT_ID --member user:$CURRENT_GKE_USER --role=roles/container.admin`

If you see other missing permissions, please add the correct role to your user. Then remember to `gcloud auth login` and make sure you have the right permissions by running:

 `PROJECT_ID=my-project-id; CURRENT_GKE_USER=$(gcloud config get account); gcloud projects get-iam-policy $PROJECT_ID --filter="bindings.members:$CURRENT_GKE_USER" --flatten="bindings[].members"`.
```

- [ y] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
