### PR TITLE
pip-changelog listed the wrong package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,4 +42,4 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 ### Added
 - Initial release of xpk PyPI package
 
-[0.1.0]: https://github.com/google/cloud-tpu-monitoring-debugging/releases/tag/v0.1.0
+[0.1.0]: https://github.com/google/xpk/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ keywords = []
 dependencies = []
 
 [project.urls]
-"Homepage" = "https://github.com/google/cloud-tpu-monitoring-debugging"
+"Homepage" = "https://github.com/google/xpk"
 "Bug Tracker" = "https://github.com/google/xpk/issues"
 
 [build-system]


### PR DESCRIPTION
## Fixes / Features
- pip changelog listed the wrong package unfortunately. renamed to be the correct one.
-

## Testing / Documentation
- No testing needed for small change.
