### PR TITLE
Xpk fix parallel node pool create

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,25 @@ might want to use `Cluster List` or `Workload List` commands. Finally, you can
 cleanup with a `Cluster Delete`.
 
 ## Cluster Create
+
+*   Cluster Create (provision reserved capacity):
+
+    ```shell
+    # Find your reservations
+    gcloud compute reservations list --project=$PROJECT_ID
+    # Run cluster create with reservation
+    python3 xpk.py cluster create \
+    --cluster xpk-test --tpu-type=v5litepod-256 \
+    --num-slices=2 \
+    --reservation=$RESERVATION_ID
+    ```
+
 *   Cluster Create (provision on-demand capacity):
 
     ```shell
     python3 xpk.py cluster create \
     --cluster xpk-test --tpu-type=v5litepod-16 \
-    --num-slices=4
-    ```
-
-
-*   Cluster Create (provision reserved capacity):
-
-    ```shell
-    python3 xpk.py cluster create \
-    --cluster xpk-test --tpu-type=v5litepod-256 \
-    --num-slices=2 \
-    --custom-tpu-nodepool-arguments="--reservation-affinity=specific --reservation=RESERVATION_ID"
+    --num-slices=4 --on-demand
     ```
 
 *   Cluster Create can be called again with the same `--cluster name` to modify

--- a/xpk.py
+++ b/xpk.py
@@ -393,10 +393,12 @@ def run_command_batch(commands, jobname, per_command_name, output_logs):
   children = []
   start_time = datetime.datetime.now()
   for i, command in enumerate(commands):
-    with subprocess.Popen(
-        command, stdout=output_logs[i], stderr=output_logs[i], shell=True
-    ) as task:
-      children.append(task)
+    children.append(
+        # subprocess managed by list pylint: disable=consider-using-with
+        subprocess.Popen(
+            command, stdout=output_logs[i], stderr=output_logs[i], shell=True
+        )
+    )
 
   while True:
     returncodes = [child.poll() for child in children]


### PR DESCRIPTION
## Fixes / Features
- the ability to do parallel node pool creation. `with` breaks this by waiting for the popen instance to close before moving on.


## Testing / Documentation

- [ y] Parallel Node Pool Creation works.
