### PR TITLE
Improve default cpu node pool configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ cleanup with a `Cluster Delete`.
 
 ## Cluster Create
 
+The cluster created is a regional cluster to enable the GKE control plane across
+all zones.
+
 *   Cluster Create (provision reserved capacity):
 
     ```shell

--- a/xpk.py
+++ b/xpk.py
@@ -696,11 +696,13 @@ def run_gke_cluster_create_command(args) -> int:
     0 if successful and 1 otherwise.
   """
 
-  # Create the cluster.
+  # Create the regional cluster with one CPU nodepool in the requested zone.
+  # Set the number of cpu nodes to start a 1 and auto-scale to fit the need.
   command = (
       'gcloud beta container clusters create'
-      f' {args.cluster} --release-channel rapid  --enable-autoscaling'
-      ' --max-nodes 1000 --min-nodes 5'
+      f' {args.cluster} --release-channel rapid --enable-autoscaling'
+      f' --max-nodes 1000 --min-nodes 1 --node-locations={args.zone}'
+      ' --num-nodes=1'
       f' --project={args.project} --region={zone_to_region(args.zone)}'
       f' --cluster-version={args.gke_version} --location-policy=BALANCED'
       f' --machine-type={args.cluster_cpu_machine_type}'
@@ -1879,7 +1881,7 @@ cluster_create_optional_arguments.add_argument(
 cluster_create_optional_arguments.add_argument(
   '--cluster-cpu-machine-type',
     type=str,
-    default='e2-standard-32',
+    default='e2-standard-4',
     help=(
       'Set the machine tpu within the default cpu node pool. For zonal '
       'clusters, make sure that the zone supports the machine type, and for '


### PR DESCRIPTION
## Fixes / Features
- Set up default cpu node pool type to be e2-standard-4 which is smaller than e2-standard-32
- Set up the cpu node pool to only be in the same zone as TPUs.
- Autoscale will increase the number of nodes in the cpu node pool as needed.

## Testing / Documentation
Tested that I can create a v5e cluster and run a workload with these new settings.
- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
