### PR TITLE
Add v5p support and increase the GKE default version to support it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ return the hardware back to the shared pool when they complete, developers can
 achieve better use of finite hardware resources. And automated tests can run
 overnight while resources tend to be underutilized.
 
+xpk supports the following TPU types:
+* v4
+* v5e
+* v5p
+
 # Installation
 To install xpk, run the following command:
 

--- a/xpk.py
+++ b/xpk.py
@@ -65,6 +65,7 @@ if (
 
 default_docker_image = 'python:3.10'
 default_script_dir = os.getcwd()
+default_gke_version="1.28.3-gke.1286000"
 
 workload_create_yaml = """apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
@@ -2158,10 +2159,10 @@ cluster_create_optional_arguments.add_argument(
 cluster_create_optional_arguments.add_argument(
     '--gke-version',
     type=str,
-    default='1.27.4-gke.900',
+    default=default_gke_version,
     help=(
         'The GKE version of the cluster and respective clusters. The default is'
-        ' "1.27.4-gke.900".'
+        f' "{default_gke_version}".'
     ),
 )
 cluster_create_optional_arguments.add_argument(

--- a/xpk.py
+++ b/xpk.py
@@ -256,6 +256,296 @@ IF YOU MODIFY THE BELOW UserFacingNameToSystemCharacteristics MAP YOU SHOULD ALS
 MODIFICATIONS TO UserFacingNameToSystemCharacteristics IN MaxText/accelerator_to_spec_map.py !!!!! """
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 UserFacingNameToSystemCharacteristics = {
+    # v5p
+    'v5p-8': SystemCharacteristics(
+      '2x2x1', 1, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-16': SystemCharacteristics(
+      '2x2x2', 2, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-32': SystemCharacteristics(
+      '2x2x4', 4, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-64': SystemCharacteristics(
+      '2x4x4', 8, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-128': SystemCharacteristics(
+      '4x4x4', 16, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-256': SystemCharacteristics(
+      '4x4x8', 32, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-384': SystemCharacteristics(
+      '4x4x12', 48, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-512': SystemCharacteristics(
+      '4x8x8', 64, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-640': SystemCharacteristics(
+      '4x4x20', 80, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-768': SystemCharacteristics(
+      '4x8x12', 96, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-896': SystemCharacteristics(
+      '4x4x28', 112, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-1024': SystemCharacteristics(
+      '8x8x8', 128, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-1152': SystemCharacteristics(
+      '4x12x12', 144, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-1280': SystemCharacteristics(
+      '4x8x20', 160, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-1408': SystemCharacteristics(
+      '4x4x44', 176, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-1536': SystemCharacteristics(
+      '8x8x12', 192, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-1664': SystemCharacteristics(
+      '4x4x52', 208, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-1792': SystemCharacteristics(
+      '4x8x28', 224, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-1920': SystemCharacteristics(
+      '4x12x20', 240, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-2048': SystemCharacteristics(
+      '8x8x16', 256, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-2176': SystemCharacteristics(
+      '4x4x68', 272, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-2304': SystemCharacteristics(
+      '8x12x12', 288, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-2432': SystemCharacteristics(
+      '4x4x76', 304, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-2560': SystemCharacteristics(
+      '8x8x20', 320, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-2688': SystemCharacteristics(
+      '4x12x28', 336, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-2816': SystemCharacteristics(
+      '4x8x44', 352, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-2944': SystemCharacteristics(
+      '4x4x92', 368, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-3072': SystemCharacteristics(
+      '4x12x16', 384, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-3200': SystemCharacteristics(
+      '4x20x20', 400, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-3328': SystemCharacteristics(
+      '4x8x52', 416, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-3456': SystemCharacteristics(
+      '12x12x12', 432, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-3584': SystemCharacteristics(
+      '8x8x28', 448, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-3712': SystemCharacteristics(
+      '4x4x116', 464, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-3840': SystemCharacteristics(
+      '8x12x20', 480, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-3968': SystemCharacteristics(
+      '4x4x124', 496, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-4096': SystemCharacteristics(
+      '8x16x16', 512, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-4224': SystemCharacteristics(
+      '4x12x44', 528, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-4352': SystemCharacteristics(
+      '4x8x68', 544, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-4480': SystemCharacteristics(
+      '4x20x28', 560, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-4608': SystemCharacteristics(
+      '12x12x16', 576, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-4736': SystemCharacteristics(
+      '4x4x148', 592, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-4864': SystemCharacteristics(
+      '4x8x76', 608, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-4992': SystemCharacteristics(
+      '4x12x52', 624, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-5120': SystemCharacteristics(
+      '8x16x20', 640, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-5248': SystemCharacteristics(
+      '4x4x164', 656, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-5376': SystemCharacteristics(
+      '8x12x28', 672, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-5504': SystemCharacteristics(
+      '4x4x172', 688, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-5632': SystemCharacteristics(
+      '8x8x44', 704, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-5760': SystemCharacteristics(
+      '12x12x20', 720, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-5888': SystemCharacteristics(
+      '4x8x92', 736, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-6016': SystemCharacteristics(
+      '4x4x188', 752, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-6144': SystemCharacteristics(
+      '12x16x16', 768, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-6272': SystemCharacteristics(
+      '4x28x28', 784, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-6400': SystemCharacteristics(
+      '8x20x20', 800, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-6528': SystemCharacteristics(
+      '4x12x68', 816, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-6656': SystemCharacteristics(
+      '8x8x52', 832, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-6784': SystemCharacteristics(
+      '4x4x212', 848, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-6912': SystemCharacteristics(
+      '12x12x24', 864, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-7040': SystemCharacteristics(
+      '4x20x44', 880, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-7168': SystemCharacteristics(
+      '8x16x28', 896, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-7296': SystemCharacteristics(
+      '4x12x76', 912, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-7424': SystemCharacteristics(
+      '4x8x116', 928, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-7552': SystemCharacteristics(
+      '4x4x236', 944, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-7680': SystemCharacteristics(
+      '12x16x20', 960, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-7808': SystemCharacteristics(
+      '4x4x244', 976, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-7936': SystemCharacteristics(
+      '4x8x124', 992, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-8064': SystemCharacteristics(
+      '12x12x28', 1008, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-8192': SystemCharacteristics(
+      '16x16x16', 1024, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-8320': SystemCharacteristics(
+      '4x20x52', 1040, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-8448': SystemCharacteristics(
+      '8x12x44', 1056, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-8704': SystemCharacteristics(
+      '8x8x68', 1088, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-8832': SystemCharacteristics(
+      '4x12x92', 1104, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-8960': SystemCharacteristics(
+      '8x20x28', 1120, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-9216': SystemCharacteristics(
+      '12x16x24', 1152, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-9472': SystemCharacteristics(
+      '4x8x148', 1184, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-9600': SystemCharacteristics(
+      '12x20x20', 1200, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-9728': SystemCharacteristics(
+      '8x8x76', 1216, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-9856': SystemCharacteristics(
+      '4x28x44', 1232, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-9984': SystemCharacteristics(
+      '8x12x52', 1248, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-10240': SystemCharacteristics(
+      '16x16x20', 1280, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-10368': SystemCharacteristics(
+      '12x12x36', 1296, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-10496': SystemCharacteristics(
+      '4x8x164', 1312, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-10752': SystemCharacteristics(
+      '12x16x28', 1344, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-10880': SystemCharacteristics(
+      '4x20x68', 1360, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-11008': SystemCharacteristics(
+      '4x8x172', 1376, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-11136': SystemCharacteristics(
+      '4x12x116', 1392, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-11264': SystemCharacteristics(
+      '8x16x44', 1408, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-11520': SystemCharacteristics(
+      '12x20x24', 1440, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-11648': SystemCharacteristics(
+      '4x28x52', 1456, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-11776': SystemCharacteristics(
+      '8x8x92', 1472, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-11904': SystemCharacteristics(
+      '4x12x124', 1488, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-12032': SystemCharacteristics(
+      '4x8x188', 1504, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-12160': SystemCharacteristics(
+      '4x20x76', 1520, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-12288': SystemCharacteristics(
+      '16x16x24', 1536, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-13824': SystemCharacteristics(
+      '12x24x24', 1728, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    'v5p-17920': SystemCharacteristics(
+      '16x20x28', 2240, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4
+    ),
+    # v5litepod
     'v5litepod-16': SystemCharacteristics(
         '4x4', 4, 'tpu-v5-lite-podslice', 'ct5lp-hightpu-4t', 4
     ),
@@ -271,6 +561,7 @@ UserFacingNameToSystemCharacteristics = {
     'v5litepod-256': SystemCharacteristics(
         '16x16', 64, 'tpu-v5-lite-podslice', 'ct5lp-hightpu-4t', 4
     ),
+    # v4
     'v4-8': SystemCharacteristics(
       '2x2x1', 1,'tpu-v4-podslice', 'ct4p-hightpu-4t', 4
     ),


### PR DESCRIPTION
## Fixes / Features
- v5p support since it is publically released: https://cloud.google.com/blog/products/ai-machine-learning/introducing-cloud-tpu-v5p-and-ai-hypercomputer
- increase gke version to support v5p

## Testing / Documentation
Created cluster with new gke version.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
