### PR TITLE
Udpate README for monitoring dashboard list permission issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,11 @@ python3 xpk.py cluster create --cluster-cpu-machine-type=CPU_TYPE ...
 
   Add [Kubernetes Engine Admin](https://cloud.google.com/iam/docs/understanding-roles#kubernetes-engine-roles) to your user.
 
+* `ERROR: (gcloud.monitoring.dashboards.list) User does not have permission to access projects instance (or it may not exist)`
+
+  Add [Monitoring Viewer](https://cloud.google.com/iam/docs/understanding-roles#monitoring.viewer) to your user.
+
+
 ## Reservation Troubleshooting:
 
 ### How to determine your reservation and its size / utilization:

--- a/xpk.py
+++ b/xpk.py
@@ -1853,7 +1853,7 @@ def get_gke_outlier_dashboard(args):
   outlier_dashboard_filter = "displayName:'GKE - TPU Monitoring Dashboard'"
   command = (
       'gcloud monitoring dashboards list'
-      f' --project={args.project} --filter="{outlier_dashboard_filter}" --format="value(name)"'
+      f' --project={args.project} --filter="{outlier_dashboard_filter}" --format="value(name)" --verbosity=error'
   )
 
   return_code, return_value = run_command_for_value(command, 'GKE Dashboard List', args)


### PR DESCRIPTION
## Fixes / Features
- Update README if user encounters the below error for Monitoring Dashboard List:
`'ERROR: (gcloud.monitoring.dashboards.list) User does not have permission to access projects instance  (or it may not exist): The caller does not have permission\n'`

## Testing / Documentation
Testing details.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
