### PR TITLE
Upgrade JobSet to v0.3.1

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -1460,7 +1460,7 @@ def set_jobset_on_cluster(args) -> int:
   """
   command = (
       'kubectl apply --server-side -f'
-      ' https://github.com/kubernetes-sigs/jobset/releases/download/v0.2.3/manifests.yaml'
+      ' https://github.com/kubernetes-sigs/jobset/releases/download/v0.3.1/manifests.yaml'
   )
   return_code = run_command_with_updates(command, 'Set Jobset On Cluster', args)
 


### PR DESCRIPTION
## Fixes / Features
Fixes #52 

## Testing / Documentation
I performed local manual testing of the following scenarios:
- **Cluster with JobSet v0.3.1 installed from the start**: I created a GKE cluster with 2 TPU v4-8 podslices, ran a sample MaxText training workload successfully.
- **Test XPK upgrade path with existing workloads**: I created a GKE cluster with 2 TPU v4-8 podslices with JobSet v0.2.3 installed, ran a MaxText workload, then updated XPK to use JobSet v0.3.1, re-ran the cluster create command (which upgraded the JobSet version), then ran another workloads. This simulates the upgrade path of current XPK users, and everything worked as expected.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
