### PR TITLE
Add device type and tpu type argument to cacheimage

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ all zones.
 
     ```shell
     python3 xpk.py cluster cacheimage \
-    --cluster xpk-test --docker-image gcr.io/your_docker_image
+    --cluster xpk-test --docker-image gcr.io/your_docker_image \
+    --tpu-type=v5litepod-16
     ```
 
 ## Workload Create
@@ -284,7 +285,7 @@ In order to use XPK for GPU, you can do so by using `device-type` flag.
     ```shell
     # Find your reservations
     gcloud compute reservations list --project=$PROJECT_ID
-    
+
     # Run cluster create with reservation.
     python3 xpk.py cluster create \
     --cluster xpk-test --device-type=h100-80gb-8 \
@@ -297,7 +298,7 @@ In order to use XPK for GPU, you can do so by using `device-type` flag.
     # List available driver versions
     gcloud compute ssh $NODE_NAME --command "sudo cos-extensions list"
 
-    # Install the default driver 
+    # Install the default driver
     gcloud compute ssh $NODE_NAME --command "sudo cos-extensions install gpu"
     # OR install a specific version of the driver
     gcloud compute ssh $NODE_NAME --command "sudo cos-extensions install gpu -- -version=DRIVER_VERSION"
@@ -497,4 +498,3 @@ To explore the stack traces collected in a temporary directory in Kubernetes Pod
   --workload xpk-test-workload --command "python3 main.py" --cluster \
   xpk-test --tpu-type=v5litepod-16 --deploy-stacktrace-sidecar
  ```
- 

--- a/xpk-large-scale-guide.sh
+++ b/xpk-large-scale-guide.sh
@@ -483,7 +483,8 @@ bash docker_upload_runner.sh CLOUD_IMAGE_NAME="${USER}"_runner
 ##### 7C #####################
 cd ../xpk
 python3 xpk.py cluster cacheimage \
- --cluster ${CLUSTER} --docker-image gcr.io/"${PROJECT}"/"${USER}"_runner
+ --cluster ${CLUSTER} --docker-image gcr.io/"${PROJECT}"/"${USER}"_runner \
+ --tpu-type=v5litepod-256
 
 # [XPK] Starting xpk
 # [XPK] Starting cluster cacheimage for cluster: xpk-test

--- a/xpk.py
+++ b/xpk.py
@@ -2712,6 +2712,21 @@ cluster_cacheimage_optional_arguments = (
         'Optional Arguments', 'Arguments optional for cluster cacheimage.'
     )
 )
+cluster_cacheimage_group = cluster_cacheimage_parser.add_mutually_exclusive_group(required=True)
+
+### Device Type Argument
+cluster_cacheimage_group.add_argument(
+    '--tpu-type',
+    type=str,
+    default=None,
+    help='The tpu type to cache images on, v5litepod-16, etc.'
+)
+cluster_cacheimage_group.add_argument(
+    '--device-type',
+    type=str,
+    default=None,
+    help='The device type to cache images on (can be tpu or gpu), v5litepod-16, h100-80gb-8, etc.'
+)
 
 ### Required arguments
 cluster_cacheimage_required_arguments.add_argument(


### PR DESCRIPTION
This sets us up for multiaccelerator support in the same cluster. This also fixes the broken cacheimage command currently.

```
 python3 xpk.py cluster cacheimage --cluster CLUSTER --docker-image IMAGE --zone=ZONE --tpu-type v5litepod-16
```

## Fixes / Features
- Fixes broken cacheimage by added tpu_type and device_type args to the command
-

## Testing / Documentation
Ran xpk cacheimage and it works now.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
