### PR TITLE
Add --tpu-topology flag for specifying custom topology types

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ all zones.
 
     ```shell
     python3 xpk.py cluster cacheimage \
-    --cluster xpk-test --docker-image gcr.io/your_docker_image
+    --cluster xpk-test --docker-image gcr.io/your_docker_image \
+    --tpu-type=v5litepod-16
     ```
 
 ## Workload Create
@@ -284,7 +285,7 @@ In order to use XPK for GPU, you can do so by using `device-type` flag.
     ```shell
     # Find your reservations
     gcloud compute reservations list --project=$PROJECT_ID
-    
+
     # Run cluster create with reservation.
     python3 xpk.py cluster create \
     --cluster xpk-test --device-type=h100-80gb-8 \
@@ -297,7 +298,7 @@ In order to use XPK for GPU, you can do so by using `device-type` flag.
     # List available driver versions
     gcloud compute ssh $NODE_NAME --command "sudo cos-extensions list"
 
-    # Install the default driver 
+    # Install the default driver
     gcloud compute ssh $NODE_NAME --command "sudo cos-extensions install gpu"
     # OR install a specific version of the driver
     gcloud compute ssh $NODE_NAME --command "sudo cos-extensions install gpu -- -version=DRIVER_VERSION"
@@ -497,4 +498,3 @@ To explore the stack traces collected in a temporary directory in Kubernetes Pod
   --workload xpk-test-workload --command "python3 main.py" --cluster \
   xpk-test --tpu-type=v5litepod-16 --deploy-stacktrace-sidecar
  ```
- 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,10 @@ workload.
 
 # More advanced facts:
 
-* Workload create accepts a --env-file flag to allow specifying the container's
+* `xpk cluster create` accepts a `--tpu-topology` flag to allow for custom tpu topologies.
+See https://cloud.google.com/kubernetes-engine/docs/concepts/tpus#topology for more details.
+
+* `xpk workload create` accepts a `--env-file`` flag to allow specifying the container's
 environment from a file. Usage is the same as Docker's
 [--env-file flag](https://docs.docker.com/engine/reference/commandline/run/#env)
 
@@ -383,7 +386,7 @@ environment from a file. Usage is the same as Docker's
     MY_ENV_VAR=hello
     ```
 
-* Workload create accepts a --debug-dump-gcs flag which is a path to GCS bucket.
+* `xpk workload create` accepts a --debug-dump-gcs flag which is a path to GCS bucket.
 Passing this flag sets the XLA_FLAGS='--xla_dump_to=/tmp/xla_dump/' and uploads
 hlo dumps to the specified GCS bucket for each worker.
 

--- a/xpk-large-scale-guide.sh
+++ b/xpk-large-scale-guide.sh
@@ -483,7 +483,8 @@ bash docker_upload_runner.sh CLOUD_IMAGE_NAME="${USER}"_runner
 ##### 7C #####################
 cd ../xpk
 python3 xpk.py cluster cacheimage \
- --cluster ${CLUSTER} --docker-image gcr.io/"${PROJECT}"/"${USER}"_runner
+ --cluster ${CLUSTER} --docker-image gcr.io/"${PROJECT}"/"${USER}"_runner \
+ --tpu-type=v5litepod-256
 
 # [XPK] Starting xpk
 # [XPK] Starting cluster cacheimage for cluster: xpk-test

--- a/xpk.py
+++ b/xpk.py
@@ -2712,6 +2712,21 @@ cluster_cacheimage_optional_arguments = (
         'Optional Arguments', 'Arguments optional for cluster cacheimage.'
     )
 )
+cluster_cacheimage_group = cluster_cacheimage_parser.add_mutually_exclusive_group(required=True)
+
+### Device Type Argument
+cluster_cacheimage_group.add_argument(
+    '--tpu-type',
+    type=str,
+    default=None,
+    help='The tpu type to cache images on, v5litepod-16, etc.'
+)
+cluster_cacheimage_group.add_argument(
+    '--device-type',
+    type=str,
+    default=None,
+    help='The device type to cache images on (can be tpu or gpu), v5litepod-16, h100-80gb-8, etc.'
+)
 
 ### Required arguments
 cluster_cacheimage_required_arguments.add_argument(

--- a/xpk.py
+++ b/xpk.py
@@ -1318,7 +1318,11 @@ def run_gke_node_pool_create_command(args, system) -> int:
         f' {args.custom_tpu_nodepool_arguments}'
     )
     if system.accelerator_type == AcceleratorType['TPU']:
-      command += (f' --tpu-topology={system.topology}')
+      tpu_topology, return_code = get_tpu_topology(system, args)
+      if return_code > 0:
+        xpk_print('Parsing tpu_topology failed!')
+        return return_code
+      command += (f' --tpu-topology={tpu_topology}')
     elif system.accelerator_type == AcceleratorType['GPU']:
       command += f' --accelerator type={system.gke_accelerator},count={str(system.chips_per_vm)}'
     task = f'NodepoolCreate-{node_pool_name}'
@@ -1554,6 +1558,35 @@ def default_subcommand_function(_args) -> int:  # args is unused, so pylint: dis
   cluster_parser.print_help()
   workload_parser.print_help()
   return 0
+
+
+def get_tpu_topology(system: SystemCharacteristics, args) -> tuple[str, int]:
+  """Function around parsing tpu-topology argument and obtaining the tpu-topology.
+
+  Args:
+    system: SystemCharacteristics for the device type.
+    args: User provided arguments for running commands.
+
+  Returns:
+  A tuple of:
+    str: topology type to use
+    int: 0 if successful and 1 otherwise.
+  """
+  if system.accelerator_type != AcceleratorType['TPU']:
+    xpk_print(
+      'tpu_topology argument is only supported when the AcceleratorType is TPU.'
+      f' The AcceleratorType you are using is: {system.accelerator_type}'
+    )
+    return None, 1
+  tpu_topology = system.topology
+  if args.tpu_topology is not None:
+    tpu_topology = args.tpu_topology
+    xpk_print(
+      f'Using custom tpu topology of {args.tpu_topology} for {system.device_type}'
+      ' in node pool creation.'
+    )
+
+  return tpu_topology, 0
 
 
 def cluster_create(args) -> int:
@@ -2518,6 +2551,18 @@ def directory_path_type(value):
   return value
 
 
+def tpu_topology_type(value, pat=re.compile(r'^[\d]+(x[\d.*]+){1,2}$')):
+  match = pat.fullmatch(value)
+  if not match:
+    raise argparse.ArgumentTypeError(
+        f'Custom TPU Topology must match the pattern `{pat.pattern}` such as 1x2x3'
+        f' or 10x10. TPU Topology set through `--tpu-topology` is currently {value}.'
+        ' See https://cloud.google.com/kubernetes-engine/docs/concepts/tpus#topology'
+        ' for more details.'
+    )
+  return value
+
+
 #### "cluster" command parser. ####
 cluster_parser = xpk_subcommands.add_parser(
     'cluster',
@@ -2604,6 +2649,16 @@ cluster_create_capacity_arguments.add_argument(
 )
 
 ### Optional Arguments
+cluster_create_optional_arguments.add_argument(
+    '--tpu-topology',
+    type=tpu_topology_type,
+    default=None,
+    help=(
+      'The slice topology to create the TPU slice with. This only supports TPUs.'
+      'By default, tpu node pool creation will use the tpu-topology defined in'
+      ' the SystemCharacteristics within xpk code.'
+    )
+)
 cluster_create_optional_arguments.add_argument(
     '--host-maintenance-interval',
     type=str,


### PR DESCRIPTION
## Fixes / Features
- Supports tpu-topology flag for specifying custom topologys for TPUs
-

## Testing / Documentation
Added a check to make sure the format of topologies fits with the argument expected and the command fails if the format is unexpected.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
