### PR TITLE
Add debug flag to workload creation to get verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,12 +532,13 @@ gcloud beta compute reservations describe $RESERVATION --project=$PROJECT_ID --z
 # TPU Workload Debugging
 
 ## Verbose Logging
-If you are having trouble with your workload, try setting the `--enable-debug-flag` when you schedule it. This will give you more detailed logs to help pinpoint the issue. For example:
+If you are having trouble with your workload, try setting the `--enable-debug-logs` when you schedule it. This will give you more detailed logs to help pinpoint the issue. For example:
 ```shell
 python3 xpk.py workload create \
 --cluster --workload xpk-test-workload \
---command="echo hello world" --enable-debug-flag
+--command="echo hello world" --enable-debug-logs
 ```
+Please check [libtpu logging](https://cloud.google.com/tpu/docs/troubleshooting/trouble-tf#debug_logs) and [Tensorflow logging](https://deepreg.readthedocs.io/en/latest/docs/logging.html#tensorflow-logging) for more information about the flags that are enabled to get the logs.
 
 ## Collect Stack Traces
 [cloud-tpu-diagnostics](https://pypi.org/project/cloud-tpu-diagnostics/) PyPI package can be used to generate stack traces for workloads running in GKE. This package dumps the Python traces when a fault such as segmentation fault, floating-point exception, or illegal operation exception occurs in the program. Additionally, it will also periodically collect stack traces to help you debug situations when the program is unresponsive. You must make the following changes in the docker image running in a Kubernetes main container to enable periodic stack trace collection.

--- a/README.md
+++ b/README.md
@@ -531,6 +531,14 @@ gcloud beta compute reservations describe $RESERVATION --project=$PROJECT_ID --z
 
 # TPU Workload Debugging
 
+## Verbose Logging
+If you are having trouble with your workload, try setting the `--enable-debug-flag` when you schedule it. This will give you more detailed logs to help pinpoint the issue. For example:
+```shell
+python3 xpk.py workload create \
+--cluster --workload xpk-test-workload \
+--command="echo hello world" --enable-debug-flag
+```
+
 ## Collect Stack Traces
 [cloud-tpu-diagnostics](https://pypi.org/project/cloud-tpu-diagnostics/) PyPI package can be used to generate stack traces for workloads running in GKE. This package dumps the Python traces when a fault such as segmentation fault, floating-point exception, or illegal operation exception occurs in the program. Additionally, it will also periodically collect stack traces to help you debug situations when the program is unresponsive. You must make the following changes in the docker image running in a Kubernetes main container to enable periodic stack trace collection.
 ```shell

--- a/xpk.py
+++ b/xpk.py
@@ -2419,6 +2419,10 @@ def workload_create(args) -> int:
     command += ('; WORKER_ID=$HOSTNAME;'
                 f'gsutil cp -r /tmp/xla_dump/ {args.debug_dump_gcs}/$WORKER_ID')
 
+  if args.enable_debug_flag:
+    command = ('TPU_STDERR_LOG_LEVEL=0 TPU_MIN_LOG_LEVEL=0 TF_CPP_MIN_LOG_LEVEL=0'
+               f' TPU_VMODULE=real_program_continuator=1 {command}')
+
   debugging_dashboard_id = None
   resource_type = AcceleratorTypeToAcceleratorCharacteristics[system.accelerator_type].resource_type
   if system.accelerator_type == AcceleratorType['TPU'] and args.deploy_stacktrace_sidecar:
@@ -3195,7 +3199,13 @@ workload_create_parser_optional_arguments.add_argument(
         'where debugging information such as HLO dumps are uploaded'
     ),
 )
-
+workload_create_parser_optional_arguments.add_argument(
+    '--enable-debug-flag',
+    action='store_true',
+    help=(
+        'Set this flag to get verbose logging to investigate the issue in the workload.'
+    ),
+)
 workload_create_parser_optional_arguments.add_argument(
     '--deploy-stacktrace-sidecar',
     action='store_true',

--- a/xpk.py
+++ b/xpk.py
@@ -2419,7 +2419,7 @@ def workload_create(args) -> int:
     command += ('; WORKER_ID=$HOSTNAME;'
                 f'gsutil cp -r /tmp/xla_dump/ {args.debug_dump_gcs}/$WORKER_ID')
 
-  if args.enable_debug_flag:
+  if args.enable_debug_logs:
     command = ('TPU_STDERR_LOG_LEVEL=0 TPU_MIN_LOG_LEVEL=0 TF_CPP_MIN_LOG_LEVEL=0'
                f' TPU_VMODULE=real_program_continuator=1 {command}')
 
@@ -3200,7 +3200,7 @@ workload_create_parser_optional_arguments.add_argument(
     ),
 )
 workload_create_parser_optional_arguments.add_argument(
-    '--enable-debug-flag',
+    '--enable-debug-logs',
     action='store_true',
     help=(
         'Set this flag to get verbose logging to investigate the issue in the workload.'


### PR DESCRIPTION
## Fixes / Features
- Add `enable-debug-flag` in workload create command to get verbose logging 

## Testing / Documentation
Logs with `enable-debug-flag` set: https://cloudlogging.app.goo.gl/c5MeQEeFEZr58qh88
Logs without `enable-debug-flag` set: https://cloudlogging.app.goo.gl/28QyKw2FbNE2bxmS7

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
