### PR TITLE
Bump JobSet to v0.3.2

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -1588,7 +1588,7 @@ def set_jobset_on_cluster(args) -> int:
   """
   command = (
       'kubectl apply --server-side -f'
-      ' https://github.com/kubernetes-sigs/jobset/releases/download/v0.3.1/manifests.yaml'
+      ' https://github.com/kubernetes-sigs/jobset/releases/download/v0.3.2/manifests.yaml'
   )
   return_code = run_command_with_updates(command, 'Set Jobset On Cluster', args)
 


### PR DESCRIPTION
JobSet v0.3.2 was released with bug fixes, improved validation, logging and clearer error messages, so I am bumping the version here.

cc @ahg-g
