### PR TITLE
Parallelize mutliple workload deletions

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ checkpointing so the job restarts near where it was interrupted.
     --cluster xpk-test
     ```
 
-    This will delete all the workloads in `xpk-test` cluster. Deletion will only begin if you type `y` or `yes` at the prompt.
+    This will delete all the workloads in `xpk-test` cluster. Deletion will only begin if you type `y` or `yes` at the prompt. Multiple workload deletions are processed in batches for optimized processing.
 
-*   Workload Delete supports filtering. Delete a portion of jobs that match user criteria.
+*   Workload Delete supports filtering. Delete a portion of jobs that match user criteria. Multiple workload deletions are processed in batches for optimized processing.
     * Filter by Job: `filter-by-job`
 
     ```shell

--- a/xpk.py
+++ b/xpk.py
@@ -2534,7 +2534,7 @@ def workload_delete(args) -> int:
     if len(workloads) == 1:
       return_code = run_command_with_updates(commands[0], 'Delete Workload', args)
     else:
-      return_code = run_commands(commands, 'Delete Workload', task_names, batch=20)
+      return_code = run_commands(commands, 'Delete Workload', task_names, batch=100)
 
     if return_code != 0:
       xpk_print(f'Delete Workload request returned ERROR {return_code}')

--- a/xpk.py
+++ b/xpk.py
@@ -2519,16 +2519,26 @@ def workload_delete(args) -> int:
   elif not will_delete:
     xpk_print("Skipping delete command.")
   else:
+    commands = []
+    task_names = []
     for workload in workloads:
       args.workload = workload
       yml_string = workload_delete_yaml.format(args=args)
       tmp = write_temporary_file(yml_string)
       command = f'kubectl delete -f {str(tmp.file.name)}'
-      return_code = run_command_with_updates(command, 'Delete Workload', args)
+      task_name = f'WorkloadDelete-{workload}'
+      commands.append(command)
+      task_names.append(task_name)
 
-      if return_code != 0:
-        xpk_print(f'Delete Workload request returned ERROR {return_code}')
-        xpk_exit(return_code)
+    # Not batching deletion for single workload
+    if len(workloads) == 1:
+      return_code = run_command_with_updates(commands[0], 'Delete Workload', args)
+    else:
+      return_code = run_commands(commands, 'Delete Workload', task_names, batch=20)
+
+    if return_code != 0:
+      xpk_print(f'Delete Workload request returned ERROR {return_code}')
+      xpk_exit(return_code)
   xpk_exit(0)
 
 


### PR DESCRIPTION
## Fixes / Features
- Adding batching to parallelize multiple workload deletions to reduce the time

## Testing
This PR has been tested to delete 100 workloads in a cluster containing 1 node of n1-standard-8.

## Testing / Documentation
- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
