### PR TITLE
Fix xpk_internal_commands in the main container.

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -2116,7 +2116,7 @@ def get_main_container(args, system, docker_image, resource_type) -> str:
   xpk_internal_commands = ""
   if args.debug_dump_gcs:
     xpk_internal_commands += ('WORKER_ID=$HOSTNAME;'
-                f'gsutil cp -r /tmp/xla_dump/ {args.debug_dump_gcs}/$WORKER_ID')
+                f'gsutil cp -r /tmp/xla_dump/ {args.debug_dump_gcs}/$WORKER_ID;')
 
   command = args.command
   if args.enable_debug_logs:
@@ -2136,7 +2136,7 @@ def get_main_container(args, system, docker_image, resource_type) -> str:
                 - bash
                 - -c
                 - |
-                  echo XPK Start: $(date) ; _sigterm() ( kill -SIGTERM $!;); trap _sigterm SIGTERM; ({command}) & PID=$!; while kill -0 $PID 2>/dev/null; do sleep 5; done; wait $PID; EXIT_CODE=$? ; {xpk_internal_commands}; echo XPK End: $(date); echo EXIT_CODE=$EXIT_CODE; exit $EXIT_CODE
+                  echo XPK Start: $(date) ; _sigterm() ( kill -SIGTERM $!;); trap _sigterm SIGTERM; ({command}) & PID=$!; while kill -0 $PID 2>/dev/null; do sleep 5; done; wait $PID; EXIT_CODE=$? ; {xpk_internal_commands} echo XPK End: $(date); echo EXIT_CODE=$EXIT_CODE; exit $EXIT_CODE
                 resources:
                   limits:
                     {resource_type}: {system.chips_per_vm}


### PR DESCRIPTION
## Fixes / Features
- If the xpk_internal_commands are empty, a syntax error is executed in the main command here - https://github.com/google/xpk/blob/main/xpk.py#L2139 . This change would fix that.

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
