### PR TITLE
update v5p-3072 topology

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -397,7 +397,7 @@ UserFacingNameToSystemCharacteristics = {
       '4x4x92', 368, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4, AcceleratorType['TPU'], 'v5p-2944'
     ),
     'v5p-3072': SystemCharacteristics(
-      '4x12x16', 384, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4, AcceleratorType['TPU'], 'v5p-3072'
+      '8x12x16', 384, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4, AcceleratorType['TPU'], 'v5p-3072'
     ),
     'v5p-3200': SystemCharacteristics(
       '4x20x20', 400, 'tpu-v5p-slice', 'ct5p-hightpu-4t', 4, AcceleratorType['TPU'], 'v5p-3200'


### PR DESCRIPTION
## Fixes 
v5p-3072 = 1536 chips = 8x12x16

## Testing / Documentation
- [x] created a v5p-3072 with 8x12x16 topology
