### PR TITLE
Add xpk inspector

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -66,13 +66,16 @@ if (
 default_docker_image = 'python:3.10'
 default_script_dir = os.getcwd()
 default_gke_version="1.28.3-gke.1286000"
+_CLUSTER_QUEUE_NAME='cluster-queue'
+_LOCAL_QUEUE_NAME='multislice-queue'
+
 
 workload_create_yaml = """apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
   name: {args.workload}
   labels:
-    kueue.x-k8s.io/queue-name: multislice-queue  # Name of the LocalQueue
+    kueue.x-k8s.io/queue-name: {local_queue_name}  # Name of the LocalQueue
     xpk.google.com/workload: {args.workload}
   annotations:
     alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool # 1:1 job replica to node pool assignment
@@ -145,7 +148,7 @@ spec:
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
-  name: "cluster-queue"
+  name: {cluster_queue_name}
 spec:
   preemption:
       reclaimWithinCohort: Never # Don't preempt other queues in the cohort.
@@ -163,9 +166,9 @@ apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue
 metadata:
   namespace: default
-  name: multislice-queue
+  name: {local_queue_name}
 spec:
-  clusterQueue: cluster-queue
+  clusterQueue: {cluster_queue_name}
 ---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -285,7 +288,7 @@ class SystemCharacteristics:
   gke_accelerator: str
   gce_machine_type: str
   chips_per_vm: int
-  accelerator_type: AcceleratorType
+  accelerator_type: AcceleratorType # type: ignore
   device_type: str
 
 ################### Subcommand Helper Functions #############
@@ -891,6 +894,24 @@ def write_temporary_file(payload):
       f.write(payload)
       f.flush()
     return tmp
+
+
+def append_temporary_file(payload, file):
+  """Appends `payload` to an already created file.
+
+  Use `write_temporary_file` to create a file.
+
+  Args:
+    payload: The string to be written to the file.
+    file: The file to append to.
+
+  Returns:
+    A file object that was written to.
+  """
+  with open(file=file.name, mode='a', encoding='utf=8') as f:
+    f.write(payload)
+    f.flush()
+  return file
 
 
 def run_command_for_value(
@@ -1554,7 +1575,9 @@ def enable_kueue_crds(args, system) -> int:
       total_chips=total_chips,
       accelerator_label=create_accelerator_label(system.accelerator_type, system),
       machine_label=create_machine_label(system.accelerator_type, system),
-      resource_type=AcceleratorTypeToAcceleratorCharacteristics[system.accelerator_type].resource_type
+      resource_type=AcceleratorTypeToAcceleratorCharacteristics[system.accelerator_type].resource_type,
+      cluster_queue_name=_CLUSTER_QUEUE_NAME,
+      local_queue_name=_LOCAL_QUEUE_NAME,
   )
   tmp = write_temporary_file(yml_string)
   command = f'kubectl apply -f {str(tmp.file.name)}'
@@ -2447,7 +2470,8 @@ def workload_create(args) -> int:
                                            affinity=get_cpu_affinity(system.accelerator_type),
                                            env=get_cpu_env(args.num_slices,system),
                                            accelerator_label=create_accelerator_label(system.accelerator_type, system),
-                                           machine_label=create_machine_label(system.accelerator_type, system))
+                                           machine_label=create_machine_label(system.accelerator_type, system),
+                                           local_queue_name=_LOCAL_QUEUE_NAME)
   tmp = write_temporary_file(yml_string)
   command = f'kubectl apply -f {str(tmp.file.name)}'
   return_code = run_command_with_updates(command, 'Creating Workload', args)
@@ -2614,7 +2638,7 @@ def determine_workload_list_filter_by_job(args) -> str:
     return workload_list_awk_command(f'{job_name_arg} ~ \"{args.filter_by_job}\"')
 
 
-def get_workload_list(args) -> None:
+def get_workload_list(args) -> tuple[int, str]:
   """Function to get the list of the workloads in the cluster.
 
   Args:
@@ -2643,11 +2667,13 @@ def get_workload_list(args) -> None:
              f'{workload_list_filter_status_cmd} {workload_list_filter_job_cmd}'
              )
 
-  return_code, return_value = run_command_for_value(command, 'List Jobs', args)
+  return_code, return_value = run_command_for_value(
+    command, f'List Jobs with filter-by-status={args.filter_by_status}'
+    f' with filter-by-jobs={args.filter_by_job}', args)
   return return_code, return_value
 
 
-def workload_list(args) -> None:
+def workload_list(args) -> int:
   """Function around workload list.
 
   Args:
@@ -2656,7 +2682,7 @@ def workload_list(args) -> None:
   Returns:
     0 if successful and 1 otherwise.
   """
-  print(args)
+  xpk_print(args)
 
   xpk_print('Starting workload list', flush=True)
   add_zone_and_project(args)
@@ -2671,6 +2697,216 @@ def workload_list(args) -> None:
     xpk_exit(return_code)
   xpk_print(return_value)
   xpk_exit(0)
+
+
+def inspector_run_command_helper(args, command, command_description, file) -> int:
+  """Runs a command for xpk inspector, and build the output file.
+
+  Args:
+    args: user provided arguments for running the command.
+    command: the cli command to run.
+    command_description: a brief description of the command run.
+    file: file to add command output to.
+
+  Returns:
+    0 if successful and 1 otherwise.
+  """
+  prefix = f'Command: {command}\nCommand Description: {command_description}\n'
+  postfix = '========================================================'
+  return_code, command_output = run_command_for_value(command, f'{command_description}', args)
+
+  if return_code != 0:
+    xpk_print(f'{command} returned ERROR {return_code} with output: {command_output}')
+    return 1
+
+  inspector_command_output = f'{prefix} \n{command_output} \n{postfix} \n'
+  append_temporary_file(inspector_command_output, file)
+
+  if args.print_to_terminal:
+    xpk_print(inspector_command_output)
+  return 0
+
+
+def inspector_run_workload_list_helper(args, command_description, file) -> int:
+  """Runs a workload list command for xpk inspector, and build the output file.
+
+  Args:
+    args: user provided arguments for running the command.
+    command_description: a brief description of the command run.
+    file: file to add command output to.
+
+  Returns:
+    0 if successful and 1 otherwise.
+  """
+  prefix = f'Command Description: {command_description}\n'
+  postfix = '========================================================'
+  return_code, command_output = get_workload_list(args)
+  if return_code != 0:
+    xpk_exit(return_code)
+  inspector_command_output = f'{prefix} \n{command_output} \n{postfix} \n'
+  append_temporary_file(inspector_command_output, file)
+  if args.print_to_terminal:
+    xpk_print(inspector_command_output)
+  return 0
+
+
+def inspector_output_link_helper(args, link, link_description, file) -> int:
+  """Outputs a link for xpk inspector to the output file.
+
+  Args:
+    args: user provided arguments for.
+    link: link to output.
+    link_description: describes what the link is for.
+    file: file to add command output to.
+
+  Returns:
+    0 if successful and 1 otherwise.
+  """
+  inspector_link = (
+    f'Link Description: {link_description}\n'
+    f'Link: {link}\n'
+    '========================================================'
+  )
+  append_temporary_file(inspector_link, file)
+  if args.print_to_terminal:
+    xpk_print(inspector_link)
+  return 0
+
+
+def inspector(args) -> int:
+  """Function around inspector which investigates failures in the kueue.
+
+  Args:
+    args: user provided arguments for running the command.
+
+  Returns:
+    0 if successful and 1 otherwise.
+  """
+  # Future Improvements for inspector:
+  # 1. Print out the resource flavor.
+  # 2. List what is next in Queue.
+  # 3. Split inspector into different subcommands to parse info easier.
+
+  final_return_code = 0
+  xpk_print(args)
+
+  add_zone_and_project(args)
+  set_cluster_command_code = set_cluster_command(args)
+  if set_cluster_command_code != 0:
+    xpk_exit(set_cluster_command_code)
+
+  inspector_file = write_temporary_file("==================\nXPK inspector OUTPUT:\n==================\n")
+  command_and_descriptions = [
+    ('gcloud version', 'Local Setup: gcloud version'),
+    ('gcloud config get project; gcloud config get compute/zone; gcloud config get compute/region',
+     'Local Setup: Project / Zone / Region'),
+    (f'gcloud beta container clusters list --project {args.project} --region {zone_to_region(args.zone)}'
+     f' | grep -e NAME -e {args.cluster}','GKE: Cluster Details'),
+    (f'gcloud beta container node-pools list --cluster {args.cluster}  --project={args.project} '
+     f'--region={zone_to_region(args.zone)}', 'GKE: Node pool Details'),
+    ('kubectl get node -o custom-columns=\'NODE_NAME:metadata.name,'
+     ' READY_STATUS:.status.conditions[?(@.type=="Ready")].status,'
+     ' NODEPOOL:metadata.labels.cloud\\.google\\.com/gke-nodepool\'', 'Kubectl: All Nodes'),
+    ('kubectl get node -o custom-columns=\':metadata.labels.cloud\\.google\\.com/gke-nodepool\''
+     ' | sort | uniq -c', 'Kubectl: Number of Nodes per Node Pool'),
+    ('kubectl get node -o custom-columns=\'NODE_NAME:metadata.name,'
+     ' READY_STATUS:.status.conditions[?(@.type=="Ready")].status,'
+     ' NODEPOOL:metadata.labels.cloud\\.google\\.com/gke-nodepool\' | grep -w True | awk {\'print $3\'} | sort | uniq -c',
+     'Kubectl: Healthy Node Count Per Node Pool'),
+    (f'kubectl describe ClusterQueue {_CLUSTER_QUEUE_NAME}', 'Kueue: ClusterQueue Details'),
+    (f'kubectl describe LocalQueue {_LOCAL_QUEUE_NAME}', 'Kueue: LocalQueue Details'),
+    ('kubectl describe Deployment kueue-controller-manager -n kueue-system', 'Kueue: Kueue Deployment Details'),
+    ('kubectl describe Deployment jobset-controller-manager -n jobset-system', 'Jobset: Deployment Details'),
+    ('kubectl logs deployment/kueue-controller-manager -n kueue-system --tail=100 --prefix=True', 'Kueue Manager Logs'),
+    ('kubectl logs deployment/jobset-controller-manager -n jobset-system --tail=100 --prefix=True', 'Jobset Manager Logs'),
+  ]
+
+  for command, description in command_and_descriptions:
+    return_code = inspector_run_command_helper(args, command, description, inspector_file)
+    if return_code != 0:
+      final_return_code = return_code
+      xpk_print(f'inspector failed in command: {command} description: {description} return code: {return_code}')
+
+  # Workload list views:
+  filter_by_statuses = ['EVERYTHING','QUEUED','RUNNING']
+  for filter_by_status in filter_by_statuses:
+    args.filter_by_job=None
+    args.filter_by_status=filter_by_status
+    command_description = (
+      f'xpk workload list --filter-by-status={args.filter_by_status}'
+      f' --filter-by-job={args.filter_by_job} --project={args.project} --zone={args.zone}'
+      f' --cluster={args.cluster}'
+    )
+    return_code = inspector_run_workload_list_helper(args, command_description, inspector_file)
+    if return_code != 0:
+      final_return_code = return_code
+      xpk_print(f'inspector failed in description: {command_description} return code: {return_code}')
+
+  # If a workload argument is provided, list out workload specific details.
+  if args.workload:
+    xpk_print(args.workload)
+    args.filter_by_job=args.workload
+    args.filter_by_status='EVERYTHING'
+    command_description = (
+      f'xpk workload list --filter-by-status={args.filter_by_status}'
+      f' --filter-by-job={args.filter_by_job} --project={args.project} --zone={args.zone}'
+      f' --cluster={args.cluster}'
+    )
+    return_code = inspector_run_workload_list_helper(args, command_description, inspector_file)
+    if return_code != 0:
+      final_return_code = return_code
+      xpk_print(f'inspector failed in description: {command_description} return code: {return_code}')
+
+    command = f'kubectl describe jobsets {args.workload}'
+    command_description = f'Jobset config for {args.workload}'
+    return_code = inspector_run_command_helper(args, command, command_description, inspector_file)
+    if return_code != 0:
+      final_return_code = return_code
+      xpk_print(f'inspector failed in command: {command} description: {command_description} return code: {return_code}')
+
+    command = f'kubectl describe workloads jobset-{args.workload}'
+    command_description = f'Workload config for {args.workload}'
+    return_code = inspector_run_command_helper(args, command, command_description, inspector_file)
+    if return_code != 0:
+      final_return_code = return_code
+      xpk_print(f'inspector failed in command: {command} description: {command_description} return code: {return_code}')
+
+  # Cloud Console Links:
+  workload_links = []
+  if args.workload:
+    workload_links = [
+      (f'Cloud Console for the workload {args.workload}',
+      # pylint: disable=line-too-long
+       f'https://console.cloud.google.com/kubernetes/service/{zone_to_region(args.zone)}/{args.cluster}/default/{args.workload}/details?project={args.project}')
+    ]
+
+  links = [
+    ('Cloud Console for the GKE Cluster',
+      # pylint: disable=line-too-long
+     f'https://console.cloud.google.com/kubernetes/clusters/details/{zone_to_region(args.zone)}/{args.cluster}/details?project={args.project}'),
+    ('Cloud Console for all workloads in GKE Cluster',
+      # pylint: disable=line-too-long
+     f'https://console.cloud.google.com/kubernetes/workload/overview?project={args.project}&pageState=((gke%2F{zone_to_region(args.zone)}%2F{args.cluster}))'),
+    ('Cloud Console for IAM Permissions', f'https://console.cloud.google.com/iam-admin/iam?project={args.project}'),
+    ('Cloud Console for Quotas', f'https://console.cloud.google.com/iam-admin/quotas?project={args.project}'),
+  ]
+  links.extend(workload_links)
+
+  for description, workload_link in links:
+    return_code = inspector_output_link_helper(args, workload_link, description, inspector_file)
+    if return_code != 0:
+      final_return_code = return_code
+      xpk_print(f'inspector failed in link: {workload_link} description: {description} return code: {return_code}')
+
+  # Summarize inspector:
+  xpk_print(f'Find xpk inspector output file: {inspector_file.name}')
+
+  if final_return_code != 0:
+    xpk_print(
+      'Something was unable to run in xpk inspector, please look through the output'
+      f' as it may clue to the failure reason. Return Code: {final_return_code}'
+    )
+  xpk_exit(final_return_code)
 
 
 def add_shared_arguments(custom_parser):
@@ -3053,7 +3289,7 @@ workload_create_parser_required_arguments = (
 )
 workload_create_parser_optional_arguments = (
     workload_create_parser.add_argument_group(
-        'Optional Arguments', 'Arguments optional for `job create`.'
+        'Optional Arguments', 'Arguments optional for `workload create`.'
     )
 )
 workload_base_docker_image_arguments = (
@@ -3073,7 +3309,7 @@ workload_docker_image_arguments = (
 )
 
 
-### Workload required arguments
+### "workload create" Required arguments
 workload_create_parser_required_arguments.add_argument(
     '--workload',
     type=workload_name_type,
@@ -3116,7 +3352,7 @@ workload_device_group.add_argument(
     help='The device type to use (can be tpu or gpu or cpu), v5litepod-16, h100-80gb-8, n2-standard-32-4 etc.'
 )
 
-### Workload Optional Arguments
+### "workload create" Optional Arguments
 add_shared_arguments(workload_create_parser_optional_arguments)
 
 workload_create_parser_optional_arguments.add_argument(
@@ -3242,7 +3478,7 @@ workload_create_parser_optional_arguments.add_argument(
 
 workload_create_parser.set_defaults(func=workload_create)
 
-# "job delete" command parser.
+# "workload delete" command parser.
 workload_delete_parser = workload_subcommands.add_parser(
     'delete', help='Delete job.'
 )
@@ -3259,7 +3495,7 @@ workload_delete_parser_optional_arguments = (
 )
 add_shared_arguments(workload_delete_parser_optional_arguments)
 
-### Required arguments
+### "workload delete" Required arguments
 workload_delete_parser_required_arguments.add_argument(
     '--cluster',
     type=str,
@@ -3268,7 +3504,7 @@ workload_delete_parser_required_arguments.add_argument(
     required=True,
 )
 
-### Optional arguments
+### "workload delete" Optional arguments
 workload_delete_parser_optional_arguments.add_argument(
     '--workload',
     type=workload_name_type,
@@ -3333,8 +3569,62 @@ workload_list_parser.add_argument(
 )
 add_shared_arguments(workload_list_parser)
 
-
 workload_list_parser.set_defaults(func=workload_list)
+
+
+#### "inspector" command parser. ####
+inspector_parser = xpk_subcommands.add_parser(
+    'inspector', help='commands around investigating workload, and Kueue failures.'
+)
+
+inspector_parser.set_defaults(func=default_subcommand_function)
+inspector_subcommands = inspector_parser.add_subparsers(
+    title='inspector subcommands',
+    dest='xpk_inspector_subcommands',
+    help='Investigate workload, and Kueue failures.',
+)
+
+inspector_parser_required_arguments = (
+    inspector_parser.add_argument_group(
+        'inspector Built-in Arguments',
+        'Arguments required for `inspector`.'
+    )
+)
+inspector_parser_optional_arguments = (
+    inspector_parser.add_argument_group(
+        'Optional Arguments', 'Arguments optional for `inspector`.'
+    )
+)
+
+### "inspector" Required arguments
+
+inspector_parser_required_arguments.add_argument(
+    '--cluster',
+    type=str,
+    default=None,
+    help='The name of the cluster to investigate.',
+    required=True,
+)
+
+### "inspector" Optional Arguments
+add_shared_arguments(inspector_parser_optional_arguments)
+
+inspector_parser_optional_arguments.add_argument(
+    '--workload',
+    type=workload_name_type,
+    default=None,
+    help='The name of the workload to investigate.',
+)
+
+inspector_parser_optional_arguments.add_argument(
+    '--print-to-terminal',
+    action='store_true',
+    help=(
+      'Prints inspector output to terminal. A user can always look at the returned file.'
+    ),
+)
+
+inspector_parser.set_defaults(func=inspector)
 
 xpk_print('Starting xpk', flush=True)
 main_args = parser.parse_args()


### PR DESCRIPTION
## Features
` python3 $XPK inspector ...` prints out debug information related to kueue, jobset, workload, gke cluster , gke node pools, and cloud console. It exports all the info needed to debug workload failures to a file to debug with.

- Prints out Cloud console links to quota page, iam permission page, gke cluster, workload, all workloads
- Set the `--workload` flag when interested in why a specific workload is not working
- Run without the workload flag to investigate general health of the gke cluster and workload management such as node pool health
- set the `--print-to-terminal` arg to print details to console.

Users can investigate the lawyer file and also share the lawyer file with experts to quickly allow investigations to uncover failures.

## Testing / Documentation
Ran the following commands:

 `python3 $XPK inspector --cluster $CLUSTER_NAME --print-to-terminal --project $PROJECT --zone $ZONE --workload vbarr-4-slice-test7-29`

 `python3 $XPK inspector --cluster $CLUSTER_NAME --print-to-terminal --project $PROJECT --zone $ZONE`

` python3 $XPK inspector --cluster $CLUSTER_NAME  --project $PROJECT --zone $ZONE`

- [ y ] Tests pass
- [ y] Appropriate changes to documentation are included in the PR
