### PR TITLE
Update default gke version for cluster to  "1.29.1-gke.1589000"

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -65,7 +65,7 @@ if (
 
 default_docker_image = 'python:3.10'
 default_script_dir = os.getcwd()
-default_gke_version="1.28.3-gke.1286000"
+default_gke_version="1.29.1-gke.1589000"
 _CLUSTER_QUEUE_NAME='cluster-queue'
 _LOCAL_QUEUE_NAME='multislice-queue'
 


### PR DESCRIPTION
## Fixes / Features
- Update default GKE version to "1.29.1-gke.1589000"

## Testing / Documentation
Testing details.

- [ y ] Tests pass
- [ n ] Appropriate changes to documentation are included in the PR
