### PR TITLE
Update the CPU machine type to be n1-standard-16 in integ tests

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -21,8 +21,8 @@ on:
     types: [submitted]
 
 jobs:
-  cluster-create-and-delete:   
-    if: ${{ (github.event.review.state == 'approved') || (github.event_name == 'push')}} 
+  cluster-create-and-delete:
+    if: ${{ (github.event.review.state == 'approved') || (github.event_name == 'push')}}
     runs-on: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v4
@@ -36,10 +36,10 @@ jobs:
       with:
         version: '>= 363.0.0'
         install_components: 'beta,gke-gcloud-auth-plugin'
-    - name: Verify gcp setup 
+    - name: Verify gcp setup
       run: gcloud info
     - name: Create an XPK Cluster with 2x v4-8 nodepools
-      run: python xpk.py cluster create --cluster test-2-v4-8-nodepool --device-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-8 --spot --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
+      run: python xpk.py cluster create --cluster test-2-v4-8-nodepool --device-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --spot --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
     - name: Delete the cluster created
       run: python xpk.py cluster delete --cluster test-2-v4-8-nodepool --zone=us-central2-b
 

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -17,10 +17,10 @@ name: Nightly Tests
 on:
   workflow_dispatch:
   schedule: #schedule the job run at 12AM PST daily
-    - cron: '0 8 * * *' 
+    - cron: '0 8 * * *'
 
 jobs:
-  cluster-create-and-delete:   
+  cluster-create-and-delete:
     runs-on: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v4
@@ -34,14 +34,14 @@ jobs:
       with:
         version: '>= 363.0.0'
         install_components: 'beta,gke-gcloud-auth-plugin'
-    - name: Verify gcp setup 
+    - name: Verify gcp setup
       run: gcloud info
     - name: Create an XPK Cluster with zero node pools
-      run: python xpk.py cluster create --cluster test-zero-nodepool --device-type=v4-8  --num-slices=0 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-8 --spot --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
+      run: python xpk.py cluster create --cluster test-zero-nodepool --device-type=v4-8  --num-slices=0 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --spot --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
     - name: Delete the cluster created
-      run: python xpk.py cluster delete --cluster test-zero-nodepool --zone=us-central2-b 
-    - name: Create an XPK Cluster with 2x v4-8 nodepools  
-      run: python xpk.py cluster create --cluster test-2-v4-8-nodepool --device-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-8 --spot --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
+      run: python xpk.py cluster delete --cluster test-zero-nodepool --zone=us-central2-b
+    - name: Create an XPK Cluster with 2x v4-8 nodepools
+      run: python xpk.py cluster create --cluster test-2-v4-8-nodepool --device-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --spot --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
     - name: Delete the cluster created
       run: python xpk.py cluster delete --cluster test-2-v4-8-nodepool --zone=us-central2-b
 


### PR DESCRIPTION
## Fixes / Features
- From n1-standard-8 to n1-standard-16
- This should fix nightly test failures where kueue crds are unable to install.

## Testing / Documentation
Install kueue crds and run integ tests. Will also see performance in nightly tests.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
