### PR TITLE
Create service account in cluster create

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ all zones.
     --num-slices=6  --reservation=$RESERVATION_ID
 
     ```
-
 ## Cluster Delete
 *   Cluster Delete (deprovision capacity):
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ all zones.
     --num-slices=6  --reservation=$RESERVATION_ID
 
     ```
+
+Cluster Create command will also create a project-specific Service Account. Note that only one service account will be created per project. This service account will be attached to the node pools to use instead of [Compute Engine default service account](https://cloud.google.com/compute/docs/access/service-accounts#default_service_account). Make sure you have [Service Account Admin](https://cloud.google.com/iam/docs/understanding-roles#iam.serviceAccountAdmin) and [Project IAM Admin](https://cloud.google.com/iam/docs/understanding-roles#resourcemanager.projectIamAdmin) roles assigned to your user account.
+
 ## Cluster Delete
 *   Cluster Delete (deprovision capacity):
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ all zones.
 
     ```
 
-Cluster Create command will also create a project-specific Service Account. Note that only one service account will be created per project. This service account will be attached to the node pools to use instead of [Compute Engine default service account](https://cloud.google.com/compute/docs/access/service-accounts#default_service_account). Make sure you have [Service Account Admin](https://cloud.google.com/iam/docs/understanding-roles#iam.serviceAccountAdmin) and [Project IAM Admin](https://cloud.google.com/iam/docs/understanding-roles#resourcemanager.projectIamAdmin) roles assigned to your user account.
-
 ## Cluster Delete
 *   Cluster Delete (deprovision capacity):
 

--- a/xpk.py
+++ b/xpk.py
@@ -1450,7 +1450,7 @@ def run_gke_cluster_create_command(args) -> int:
       ' --scopes=storage-full,gke-default'
       f' {args.custom_cluster_arguments}'
   )
-  
+
   if _SERVICE_ACCOUNT_FEATURE_FLAG:
     service_account_name = get_service_account_name(args)
     service_account_exists = check_if_service_account_exists(args)

--- a/xpk.py
+++ b/xpk.py
@@ -73,7 +73,7 @@ _CLUSTER_RESOURCES_CONFIGMAP = 'resources-configmap'
 _CLUSTER_METADATA_CONFIGMAP = 'metadata-configmap'
 _XPK_SERVICE_ACCOUNT = 'xpk-sa'
 # Set to True to attach a service account to cluster & node pools
-_USE_SERVICE_ACCOUNT = False
+_SERVICE_ACCOUNT_FEATURE_FLAG = xpk_current_version >= "0.4.0"
 
 
 workload_create_yaml = """apiVersion: jobset.x-k8s.io/v1alpha2
@@ -1289,7 +1289,7 @@ def run_gke_cluster_create_command(args) -> int:
       ' --scopes=storage-full,gke-default'
       f' {args.custom_cluster_arguments}'
   )
-  if _USE_SERVICE_ACCOUNT:
+  if _SERVICE_ACCOUNT_FEATURE_FLAG:
     service_account_name = get_service_account_name(args)
     service_account_exists = check_if_service_account_exists(args)
     if service_account_exists:
@@ -1604,7 +1604,7 @@ def run_gke_node_pool_create_command(args, system) -> int:
     elif system.accelerator_type == AcceleratorType['GPU']:
       command += (' --placement-type=COMPACT ')
       command += f' --accelerator type={system.gke_accelerator},count={str(system.chips_per_vm)}'
-    if _USE_SERVICE_ACCOUNT:
+    if _SERVICE_ACCOUNT_FEATURE_FLAG:
       service_account_name = get_service_account_name(args)
       service_account_exists = check_if_service_account_exists(args)
       if service_account_exists:
@@ -1846,7 +1846,7 @@ def cluster_create(args) -> int:
   xpk_print(f'Starting cluster create for cluster {args.cluster}:', flush=True)
   add_zone_and_project(args)
 
-  if _USE_SERVICE_ACCOUNT:
+  if _SERVICE_ACCOUNT_FEATURE_FLAG:
     service_account_name = get_service_account_name(args)
     service_account_exists = check_if_service_account_exists(args)
     if service_account_exists:


### PR DESCRIPTION
## Fixes / Features
- Create a project-specific service account in cluster create
- All the required permissions for the workload will be assigned to this new service account
- This service account will replace Compute Engine default service account for cluster & node-pools
- This functionality will be done behind a flag `_USE_SERVICE_ACCOUNT` to prevent breakage for current xpk users

## Testing / Documentation
Testing details.

- [ y ] Tests pass
- [ N/A ] Appropriate changes to documentation are included in the PR
