### PR TITLE
Move always() to be part of the delete step

### DIFF
--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -40,8 +40,8 @@ jobs:
       run: python xpk.py cluster create --cluster test-zero-nodepool --device-type=v4-8  --num-slices=0 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --spot --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
     - name: Delete the cluster created
       run: python xpk.py cluster delete --cluster test-zero-nodepool --zone=us-central2-b
-    - name: Create an XPK Cluster with 2x v4-8 nodepools
       if: always()
+    - name: Create an XPK Cluster with 2x v4-8 nodepools
       run: python xpk.py cluster create --cluster test-2-v4-8-nodepool --device-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --spot --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
     - name: Delete the cluster created
       if: always()


### PR DESCRIPTION
## Fixes / Features
- If the empty node pool step fails, we want to clean up the cluster. Currently if it fails, it will the TPU test.

## Testing / Documentation
Testing details.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
