### PR TITLE
Create a queue of nightly / build tests to avoid concurrent tests to step on each other

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -22,6 +22,9 @@ on:
 jobs:
   cluster-create-and-delete:
     runs-on: [ubuntu-20.04]
+    concurrency: # We support one build or nightly test to run at a time currently.
+      group: cluster-test-group
+      cancel-in-progress: false
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -22,6 +22,9 @@ on:
 jobs:
   cluster-create-and-delete:
     runs-on: [ubuntu-20.04]
+    concurrency: # We support one build test to run at a time currently.
+      group: cluster-test-group
+      cancel-in-progress: false
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5


### PR DESCRIPTION

## Fixes / Features
-  Presents several build tests / nightly tests to run at the same time since we use the same cluster name across different test instances.

## Testing / Documentation
Will need to see parallel tests queued up.
- [ y] Tests pass
- [ y] Appropriate changes to documentation are included in the PR
