### PR TITLE
Create Tensorboard instance in Vertex AI in cluster create

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -2747,6 +2747,9 @@ def cluster_create(args) -> int:
   tensorboard_config = {}
   if _VERTEX_TENSORBOARD_FEATURE_FLAG and args.create_vertex_tensorboard:
     tensorboard_config = create_vertex_tensorboard(args)
+    # exit if failed to create Tensorboard in Vertex AI
+    if not tensorboard_config:
+      xpk_exit(1)
 
   device_type = args.tpu_type if args.tpu_type else args.device_type
   if device_type == h100_device_type:


### PR DESCRIPTION
## Fixes / Features
- Add a functionality to create Tensorboard instance in Vertex AI during cluster creation
-  This functionality is behind a flag `create-vertex-tensorboard`. Vertex Tensorboard instance will only be created when this flag is added to cluster create command. 

## Scenarios:
*Example 1:*
`python3 xpk.py cluster create --cluster test --num-slices=1 --tpu-type=v4-8 --zone=us-central2-b  --project=test-project --create-vertex-tensorboard`

will create a Tensorboard instance with the name `test-tb-instance` in `us-central1`

*Example 2:* 
`python3 xpk.py cluster create --cluster test --num-slices=1 --tpu-type=v4-8 --zone=us-central2-b  --project=test-project --create-vertex-tensorboard --tensorboard-region=us-east1`

will create a Tensorboard instance with the name `test-tb-instance` in `us-east1`

*Example 3:* 
`python3 xpk.py cluster create --cluster test --num-slices=1 --tpu-type=v4-8 --zone=us-central2-b  --project=test-project --create-vertex-tensorboard --tensorboard-region=us-east1 --tensorboard-name=tb-testing`

will create a Tensorboard instance with the name `tb-testing` in `us-east1`

*Example 4:* 
`python3 xpk.py cluster create --cluster test --num-slices=1 --tpu-type=v4-8 --zone=us-central2-b  --project=test-project --create-vertex-tensorboard --tensorboard-name=tb-testing`

will create a Tensorboard instance with the name `tb-testing` in `us-central1`

*Example 5:*
`python3 xpk.py cluster create --cluster test --num-slices=1 --tpu-type=v4-8 --zone=us-central2-b  --project=test-project --create-vertex-tensorboard --tensorboard-region=us-central2 --tensorboard-name=tb-testing`

will output the following error and fail the cluster creation process:
```
Error while creating Tensorboard instance.
Traceback (most recent call last):
  File "/usr/local/google/home/sjsurbhi/xpk/lib/python3.11/site-packages/cloud_accelerator_diagnostics/src/tensorboard_uploader/tensorboard.py", line 34, in create_instance
    aiplatform.init(project=project, location=location)
  File "/usr/local/google/home/sjsurbhi/xpk/lib/python3.11/site-packages/google/cloud/aiplatform/initializer.py", line 223, in init
    utils.validate_region(location)
  File "/usr/local/google/home/sjsurbhi/xpk/lib/python3.11/site-packages/google/cloud/aiplatform/utils/__init__.py", line 291, in validate_region
    raise ValueError(
ValueError: Unsupported region for Vertex AI, select from frozenset({'asia-northeast3', 'europe-central2', 'asia-east2', 'us-east4', 'asia-east1', 'europe-west3', 'southamerica-east1', 'southamerica-west1', 'us-west2', 'europe-west2', 'europe-west8', 'europe-west4', 'us-central1', 'asia-south1', 'europe-west1', 'northamerica-northeast2', 'asia-southeast1', 'northamerica-northeast1', 'europe-southwest1', 'asia-northeast2', 'asia-southeast2', 'asia-northeast1', 'me-west1', 'us-east1', 'us-west4', 'europe-west6', 'australia-southeast1', 'australia-southeast2', 'us-west3', 'us-west1', 'us-south1', 'europe-north1', 'europe-west9'})
[XPK] XPK failed, error code 1
```

## Testing / Documentation
Testing details.

- [ y ] Tests pass
- [ n ] Appropriate changes to documentation are included in the PR
