### PR TITLE
XPK update for hybridsim

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -123,10 +123,15 @@ spec:
                 volumeMounts:
                 - mountPath: /dev/shm
                   name: dshm-2
+                - mountPath: /var/run/docker.sock
+                  name: docker-socket-volume
               volumes:
               - emptyDir:
                   medium: Memory
                 name: dshm-2
+              - name: docker-socket-volume
+                hostPath:
+                  path: /var/run/docker.sock
 """
 
 gpu_workload_create_yaml = """apiVersion: jobset.x-k8s.io/v1alpha2

--- a/xpk.py
+++ b/xpk.py
@@ -125,6 +125,8 @@ spec:
                   name: dshm-2
                 - mountPath: /var/run/docker.sock
                   name: docker-socket-volume
+                - mountPath: /tmp/xla_dump/
+                  name: xla-dump-volume
               volumes:
               - emptyDir:
                   medium: Memory
@@ -132,6 +134,9 @@ spec:
               - name: docker-socket-volume
                 hostPath:
                   path: /var/run/docker.sock
+              - name: xla-dump-volume
+                hostPath:
+                  path: /tmp/xla_dump/
 """
 
 gpu_workload_create_yaml = """apiVersion: jobset.x-k8s.io/v1alpha2


### PR DESCRIPTION
## Fixes / Features
For `AOT+Hybridsim` integration, we need to pull Hybridsim docker image, so we need to mount `/var/run/docker.sock` (https://screenshot.googleplex.com/BD3SMwL57tP5cQY)
For running Hybridsim, we need to mount `/tmp/xla_dump/` so the Hybridsim docker image can access to HLO graph (https://screenshot.googleplex.com/64Fwrjwt6g55orn)

## Testing / Documentation
Tested `AOT+Hybridsim` e2e on a GKE node: https://screenshot.googleplex.com/5LQwBNBp4p6iyLq

This should be a combo PR of Maxtext and XPK:
https://github.com/google/maxtext/pull/564
https://github.com/google/xpk/pull/102

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
