### PR TITLE
Support --env flag and Artifact Registry image validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,11 +592,16 @@ workload.
 
 # More advanced facts:
 
-* Workload create accepts a --env-file flag to allow specifying the container's
+* Workload create has two mutually exclusive ways to override the environment of a workload:
+  *  a `--env` flag to specify each environment variable separately. The format is:
+
+     `--env VARIABLE1=value --env VARIABLE2=value`
+
+  *  a `--env-file` flag to allow specifying the container's
 environment from a file. Usage is the same as Docker's
 [--env-file flag](https://docs.docker.com/engine/reference/commandline/run/#env)
 
-    Example File:
+    Example Env File:
     ```shell
     LIBTPU_INIT_ARGS=--my-flag=true --performance=high
     MY_ENV_VAR=hello

--- a/xpk.py
+++ b/xpk.py
@@ -1252,13 +1252,13 @@ def add_env_config(args):
   device_type = args.tpu_type if args.tpu_type else args.device_type
   env = {'JOBSET_NAME': args.workload}
 
+  env_pat = re.compile(r'(^[a-zA-Z_][a-zA-Z0-9_]*?)(?:=(.*))?$', re.M)
   if args.env_file:
     print('Setting container environment from', args.env_file)
-    pat = re.compile(r'(^[a-zA-Z_][a-zA-Z0-9_]*?)(?:=(.*))$', re.M)
     with open(file=args.env_file, mode='r', encoding='utf-8') as f:
-      for match in pat.finditer(f.read()):
+      for match in env_pat.finditer(f.read()):
         variable = match.group(1)
-        if len(match.groups()) > 1:
+        if match.group(2) is not None:
           env[variable] = match.group(2)
         else:
           assert variable in os.environ, (
@@ -1266,6 +1266,15 @@ def add_env_config(args):
               'environment, a value must be specified.'
           )
           env[variable] = os.environ[variable]
+  if args.env:
+    for var in args.env:
+      match = env_pat.match(var)
+      assert match and match.group(2) is not None, (
+          'Invalid environment variable, format must be '
+          f'`--env VARIABLE=value`: {var}'
+      )
+      variable = match.group(1)
+      env[variable] = match.group(2)
 
   if args.debug_dump_gcs:
     if args.use_pathways:
@@ -2966,7 +2975,7 @@ def validate_docker_image(docker_image, args) -> int:
 
   project = args.project
 
-  if docker_image.find('gcr.io') == -1:
+  if not any(repo in docker_image for repo in ['gcr.io', 'docker.pkg.dev']):
     return 0
 
   command = (
@@ -4773,7 +4782,8 @@ workload_create_parser_optional_arguments.add_argument(
     default=1,
     help='The number of nodes to use, default=1.',
 )
-workload_create_parser_optional_arguments.add_argument(
+workload_env_arguments = workload_create_parser_optional_arguments.add_mutually_exclusive_group()
+workload_env_arguments.add_argument(
     '--env-file',
     type=str,
     default=None,
@@ -4783,6 +4793,15 @@ workload_create_parser_optional_arguments.add_argument(
         'value) or <variable> (which takes the value from the local '
         'environment), and # for comments.'
     ),
+)
+workload_env_arguments.add_argument(
+    '--env',
+    action='append',
+    type=str,
+    help=(
+        'Environment variable to set in the container environment. '
+        'The format is <variable>=value'
+    )
 )
 workload_create_parser_optional_arguments.add_argument(
     '--priority',


### PR DESCRIPTION
## Fixes / Features
- Individual environment variables can be set with `--env`
- Validate existence of ArtifactRegistry images before workload creation

## Testing / Documentation
Ran a few validation workloads:
- Nonexistent AR image will fail validation: https://paste.googleplex.com/6298050852552704#l=1
- Existing AR image will succeed: https://paste.googleplex.com/5135260269936640#l=18
- `--env` format is enforced: https://paste.googleplex.com/5226635967594496
- Specified variables are applied to the container: https://paste.googleplex.com/6198367050268672
- Multiple `--env` may be specified on a single workload: https://paste.googleplex.com/6259857570660352
- `--env` and `--env-file` are mutually exclusive: https://paste.googleplex.com/5719129935314944

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
