### PR TITLE
Add warning when user schedules workload on a cluster created using previous XPK version

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -3842,11 +3842,11 @@ def workload_create(args) -> int:
               "We recommend to upgrade your cluster by running `xpk cluster create`.")
   else:
     cluster_xpk_version = cluster_config_map.get("xpk_version")
-  if cluster_xpk_version is not None and cluster_xpk_version < xpk_current_version:
+  if cluster_xpk_version is not None and cluster_xpk_version != xpk_current_version:
     xpk_print(f"Warning: Cluster has been created using XPK version: {cluster_config_map['xpk_version']} "
               f"but the XPK version you are using to schedule workload is: {xpk_current_version}. "
-              "Some features might not be available for this cluster. We recommend to upgrade your "
-              "cluster by running `xpk cluster create` or downgrade your XPK version.")
+              "Some features might not be available for this cluster. We recommend to upgrade/downgrade "
+              "your XPK version or cluster by running `xpk cluster create`.")
 
   setup_docker_image_code, docker_image = setup_docker_image(args)
   if setup_docker_image_code != 0:

--- a/xpk.py
+++ b/xpk.py
@@ -3834,6 +3834,20 @@ def workload_create(args) -> int:
 
   xpk_print("Starting workload create", flush=True)
 
+  metadata_configmap_name = f'{args.cluster}-{_CLUSTER_METADATA_CONFIGMAP}'
+  cluster_config_map = get_cluster_configmap(args, metadata_configmap_name)
+  cluster_xpk_version = None
+  if cluster_config_map is None:
+    xpk_print(f"Warning: Unable to find ConfigMap: {metadata_configmap_name} for the cluster. "
+              "We recommend to upgrade your cluster by running `xpk cluster create`.")
+  else:
+    cluster_xpk_version = cluster_config_map.get("xpk_version")
+  if cluster_xpk_version is not None and cluster_xpk_version < xpk_current_version:
+    xpk_print(f"Warning: Cluster has been created using XPK version: {cluster_config_map['xpk_version']} "
+              f"but the XPK version you are using to schedule workload is: {xpk_current_version}. "
+              "Some features might not be available for this cluster. We recommend to upgrade your "
+              "cluster by running `xpk cluster create` or downgrade your XPK version.")
+
   setup_docker_image_code, docker_image = setup_docker_image(args)
   if setup_docker_image_code != 0:
     xpk_exit(setup_docker_image_code)


### PR DESCRIPTION
## Fixes / Features
- Warn users that as xpk version increases, there will be features that are not supported or tested in clusters created by previous versions of xpk.
- Add a warning when running workload create. If users want to be safe they are recommended to upgrade.

## Testing / Documentation
Testing details.

- [ y ] Tests pass
- [ n/a ] Appropriate changes to documentation are included in the PR
