### PR TITLE
Add Support for Pathways Expected Instances & Larger Default Worker Backoff Limit

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -1899,6 +1899,7 @@ PathwaysExpectedInstancesMap = {
     'v3': 'v3',
 }
 
+
 def chunks(lst, n):
   """Return a list of n-sized chunks from lst.
 
@@ -4846,27 +4847,34 @@ def get_pathways_rm_args(args, system: SystemCharacteristics) -> str:
               - --pathways_tmp_dir_pattern={args.pathways_gcs_location}
               - --pathways_expected_instances={expected_instances}"""
   if args.use_pathways:
-    return yaml.format(args=args, expected_instances=compute_pathways_expected_instances(args, system))
+    return yaml.format(
+        args=args,
+        expected_instances=compute_pathways_expected_instances(args, system),
+    )
   else:
     return ''
 
-def compute_pathways_expected_instances(args, system: SystemCharacteristics) -> str:
+
+def compute_pathways_expected_instances(
+    args, system: SystemCharacteristics
+) -> str:
   """Computes the expected instances from the system characteristics.
   Args:
     args: user provided args.
     system: system characteristics.
 
   Returns:
-    str: formatted string representing the expected instances (eg: 
+    str: formatted string representing the expected instances (eg:
     "tpuv4:2x2x2,tpuv4:2x2x2" for 2 slices of v4-16).
   """
   expected_instances = ','.join([
-      f'tpu{get_pathways_expected_tpu_type(system.device_type)}:{system.topology}' 
+      f'tpu{get_pathways_expected_tpu_type(system.device_type)}:{system.topology}'
       for _ in range(args.num_slices)
   ])
 
   xpk_print(f'Pathways expected instances are: {expected_instances}')
   return expected_instances
+
 
 def get_pathways_expected_tpu_type(device_type: str) -> str:
   """Returns the device type expected by Pathways
@@ -4879,9 +4887,13 @@ def get_pathways_expected_tpu_type(device_type: str) -> str:
   raw_type = device_type.split('-')[0].lower()
   pathways_expected_instance = PathwaysExpectedInstancesMap[raw_type]
   if not pathways_expected_instance:
-    xpk_print(f'Passed in device_type {device_type} is incorrect. Please pass in a valid device type')
+    xpk_print(
+        f'Passed in device_type {device_type} is incorrect. Please pass in a'
+        ' valid device type'
+    )
     xpk_exit(1)
   return pathways_expected_instance
+
 
 def get_pathways_worker_args(args) -> str:
   """Arguments for the Pathways workers.

--- a/xpk.py
+++ b/xpk.py
@@ -1113,7 +1113,7 @@ PathwaysExpectedInstancesMap = {
     "v5p": "v5",
     "v5e": "v5e",
     "v4": "v4",
-    "v3"" "v3,
+    "v3"" "v3",
 }
 
 def chunks(lst, n):
@@ -5809,14 +5809,6 @@ workload_pathways_workload_arguments.add_argument(
     default='gs://cloud-pathways-staging/tmp',
     help=(
         'Please provide the GCS location to store Pathways artifacts.'
-    ),
-)
-workload_pathways_workload_arguments.add_argument(
-    '--pathways-expected-instances',
-    type=str,
-    default='',
-    help=(
-        'Please provide the expected instances (eg: tpuv4:2x2x2,tpuv4:2x2x2).'
     ),
 )
 workload_vertex_tensorboard_arguments.add_argument(

--- a/xpk.py
+++ b/xpk.py
@@ -3888,10 +3888,10 @@ def compute_pathways_expected_instances(args, system: SystemCharacteristics) -> 
     str: formatted string representing the expected instances (eg: 
     "tpuv4:2x2x2,tpuv4:2x2x2" for 2 slices of v4-16).
   """
-  expected_instances = [
+  expected_instances = ','.join([
       f'tpu{get_pathways_expected_tpu_type(system.device_type)}:{system.topology}' 
       for _ in range(args.num_slices)
-  ].join(',')
+  ])
 
   xpk_print(f'Pathways expected instances are: {expected_instances}')
   return expected_instances

--- a/xpk.py
+++ b/xpk.py
@@ -270,11 +270,12 @@ spec:
         labels:
           xpk.google.com/workload: {args.workload}
       spec:
-        backoffLimit: 0
+        backoffLimit: {args.pw_worker_backoff_limit}
         completions: {system.vms_per_slice}
         parallelism: {system.vms_per_slice}
         template:
           spec:
+            terminationGracePeriodSeconds: {args.termination_grace_period_seconds}
             containers:
             - args:
               {pathways_worker_args}
@@ -310,7 +311,7 @@ spec:
         labels:
           xpk.google.com/workload: {args.workload}
       spec:
-        backoffLimit: 0
+        backoffLimit: {args.pw_rm_backoff_limit}
         completions: 1
         parallelism: 1
         template:
@@ -359,7 +360,7 @@ spec:
         labels:
           xpk.google.com/workload: {args.workload}
       spec:
-        backoffLimit: 0
+        backoffLimit: {args.pw_proxy_backoff_limit}
         completions: 1
         parallelism: 1
         template:
@@ -385,7 +386,7 @@ spec:
         labels:
           xpk.google.com/workload: {args.workload}
       spec:
-        backoffLimit: 0
+        backoffLimit: {args.pw_user_job_backoff_limit}
         completions: 1
         parallelism: 1
         template:
@@ -3864,7 +3865,7 @@ def get_pathways_rm_args(args) -> str:
               - --pathways_persistent_compilation_cache=false
               - --pathways_compilation_mode=compile_at_worker
               - --pathways_tmp_dir_pattern={args.pathways_gcs_location}
-              - --pathways_resource_manager_expected_num_worker_jobs={args.num_slices}"""
+              - --pathways_expected_instances={args.pathways_expected_instances}"""
   if args.use_pathways:
     return yaml.format(args=args)
   else:
@@ -5770,6 +5771,50 @@ workload_pathways_workload_arguments.add_argument(
     default='gs://cloud-pathways-staging/tmp',
     help=(
         'Please provide the GCS location to store Pathways artifacts.'
+    ),
+)
+workload_pathways_workload_arguments.add_argument(
+    '--pathways-expected-instances',
+    type=str,
+    default='',
+    help=(
+        'Please provide the expected instances (eg: tpuv4:2x2x2,tpuv4:2x2x2).'
+    ),
+)
+workload_pathways_workload_arguments.add_argument(
+    '--pw-worker-backoff-limit',
+    type=int,
+    required=False,
+    default=0,
+    help=(
+        'The number of times to restart the job.'
+    ),
+)
+workload_pathways_workload_arguments.add_argument(
+    '--pw-rm-backoff-limit',
+    type=int,
+    required=False,
+    default=0,
+    help=(
+        'The number of times to restart the job.'
+    ),
+)
+workload_pathways_workload_arguments.add_argument(
+    '--pw-proxy-backoff-limit',
+    type=int,
+    required=False,
+    default=0,
+    help=(
+        'The number of times to restart the job.'
+    ),
+)
+workload_pathways_workload_arguments.add_argument(
+    '--pw-user-job-backoff-limit',
+    type=int,
+    required=False,
+    default=0,
+    help=(
+        'The number of times to restart the job.'
     ),
 )
 workload_vertex_tensorboard_arguments.add_argument(

--- a/xpk.py
+++ b/xpk.py
@@ -1111,7 +1111,7 @@ Map in MaxText/accelerator_to_spec_map.py """
 
 PathwaysExpectedInstancesMap = {
     "v5p": "v5",
-    "v5e": "v5e",
+    "v5litepod": "v5e",
     "v4": "v4",
     "v3": "v3",
 }
@@ -3878,7 +3878,7 @@ def get_pathways_rm_args(args, system: SystemCharacteristics) -> str:
   else:
     return ""
 
-def compute_pathways_expected_instances(args, system: SystemCharacteristics):
+def compute_pathways_expected_instances(args, system: SystemCharacteristics) -> str:
   """Computes the expected instances from the system characteristics.
   Args:
     args: user provided args.
@@ -3896,7 +3896,7 @@ def compute_pathways_expected_instances(args, system: SystemCharacteristics):
   xpk_print(f'Pathways expected instances are: {expected_instances}')
   return expected_instances
 
-def get_pathways_expected_tpu_type(device_type):
+def get_pathways_expected_tpu_type(device_type: str) -> str:
   """Returns the device type expected by Pathways
   Args:
     device_type: the system characteristic device type
@@ -3904,7 +3904,7 @@ def get_pathways_expected_tpu_type(device_type):
   Returns:
     str: the device type expected by pathways.
   """
-  raw_type = lower(device_type.split('-')[0])
+  raw_type = device_type.split('-')[0].lower()
   pathways_expected_instance = PathwaysExpectedInstancesMap[raw_type]
   if not pathways_expected_instance:
     raise argparse.ArgumentTypeError(f'Passed in device_type {device_type} is incorrect. Please pass in a valid device type')

--- a/xpk.py
+++ b/xpk.py
@@ -3905,7 +3905,8 @@ def get_pathways_expected_tpu_type(device_type: str) -> str:
   raw_type = device_type.split('-')[0].lower()
   pathways_expected_instance = PathwaysExpectedInstancesMap[raw_type]
   if not pathways_expected_instance:
-    raise argparse.ArgumentTypeError(f'Passed in device_type {device_type} is incorrect. Please pass in a valid device type')
+    xpk_print(f'Passed in device_type {device_type} is incorrect. Please pass in a valid device type')
+    xpk_exit(1)
   return pathways_expected_instance
 
 def get_pathways_worker_args(args) -> str:

--- a/xpk.py
+++ b/xpk.py
@@ -1113,7 +1113,7 @@ PathwaysExpectedInstancesMap = {
     "v5p": "v5",
     "v5e": "v5e",
     "v4": "v4",
-    "v3"" "v3",
+    "v3": "v3",
 }
 
 def chunks(lst, n):

--- a/xpk.py
+++ b/xpk.py
@@ -1893,10 +1893,10 @@ the corresponding Map in MaxText/accelerator_to_spec_map.py """
 
 
 PathwaysExpectedInstancesMap = {
-    "v5p": "v5",
-    "v5litepod": "v5e",
-    "v4": "v4",
-    "v3": "v3",
+    'v5p': 'v5',
+    'v5litepod': 'v5e',
+    'v4': 'v4',
+    'v3': 'v3',
 }
 
 def chunks(lst, n):


### PR DESCRIPTION
## Fixes / Features
- Changes to support `pathways_expected_instances` (replaces `pathways_resource_manager_expected_num_worker_jobs`), which is more accurate as it includes topology information.
- Sets default backoff limit for pathways workers to 4.
- Added `terminationGracePeriodSeconds` to workers on Pathways. This allows the user to specify the timeframe workers may need to save state and gracefully exit if preempted. 

## Testing / Documentation
Validated manually with XPK create command below.

```
python3 xpk.py workload create --workload ${WORKLOAD_NAME} --cluster ${CLUSTER} --num-slices=${NUM_SLICES} --tpu-type=${TPU_TYPE} --use-pathways --project $PROJECT --zone $ZONE --docker-image="gcr.io/cloud-tpu-multipod-dev/${USER}_runner" --command="${COMMAND}" --server-image="gcr.io/cloud-tpu-multipod-dev/pathways-prototype/server/${USER}:server" --proxy-server-image="gcr.io/cloud-tpu-multipod-dev/pathways-prototype/gke/${USER}:server" --pathways-gcs-location="${LOCATION}" --termination-grace-period-seconds="${TERMINATION_GRACE_PERIOD}" --max-restarts=4
```

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
