### PR TITLE
Prevent Pathways SIGTERMs from counting against backoffLimit

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -265,10 +265,20 @@ spec:
           xpk.google.com/workload: {args.workload}
       spec:
         backoffLimit: 4
+        podFailurePolicy:
+          rules:
+          - action: Ignore          # one of: Ignore, FailJob, Count
+            onExitCodes:
+              containerName: "pathways-worker"
+              operator: In          # one of: In, NotIn
+              # TODO: verify this is the correct exit code
+              values: [143]         # Don't count SIGTERMed workers against the backoffLimit
+            onPodConditions: []
         completions: {system.vms_per_slice}
         parallelism: {system.vms_per_slice}
         template:
           spec:
+            restartPolicy: Never
             terminationGracePeriodSeconds: {args.termination_grace_period_seconds}
             containers:
             - args:


### PR DESCRIPTION
## Fixes / Features
- Add podFailurePolicy so SIGTERMed Pathways workers do not count against the default backoffLimit (4). 

## Testing / Documentation
TODO

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
