### PR TITLE
Update xpk.py

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -67,7 +67,7 @@ if (
 
 default_docker_image = 'python:3.10'
 default_script_dir = os.getcwd()
-default_gke_version = '1.29.1-gke.1589017'
+default_gke_version = '1.29.3-gke.1093000'
 # This is the version for XPK PyPI package
 __version__ = '0.4.0'
 xpk_current_version = __version__


### PR DESCRIPTION
update default version for gke

## Fixes / Features
- tcpx does not work with the default cluster version
