### PR TITLE
Allow JAX coordinator to find the JobSet name.

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -5261,8 +5261,6 @@ def get_cpu_env(num_slices, env_vars, system) -> str:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['jobset.sigs.k8s.io/replicatedjob-name']
-                - name: JAX_COORDINATOR_ADDRESS
-                  value: "$(JOBSET_NAME)-$(REPLICATED_JOB_NAME)-0-0.$(JOBSET_NAME)"
                 - name: JOB_INDEX
                   valueFrom:
                     fieldRef:
@@ -5276,6 +5274,8 @@ def get_cpu_env(num_slices, env_vars, system) -> str:
                 - name: JAX_PROCESS_COUNT
                   value: "{process_count}"
                 {env_vars}
+                - name: JAX_COORDINATOR_ADDRESS
+                  value: "$(JOBSET_NAME)-$(REPLICATED_JOB_NAME)-0-0.$(JOBSET_NAME)"
   """
   return yaml.format(
       processes_in_job=system.vms_per_slice,


### PR DESCRIPTION
## Fixes / Features
- CPU based workloads are not able to find the JAX coordinator. Reordering of env vars is needed following - https://github.com/google/xpk/pull/124

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
