### PR TITLE
Update pathways server and proxy server image locations

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -7209,7 +7209,9 @@ workload_pathways_workload_arguments.add_argument(
 workload_pathways_workload_arguments.add_argument(
     '--proxy-server-image',
     type=str,
-    default='us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest',
+    default=(
+        'us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest'
+    ),
     help='Please provide the proxy server image for Pathways.',
 )
 workload_pathways_workload_arguments.add_argument(

--- a/xpk.py
+++ b/xpk.py
@@ -7209,13 +7209,13 @@ workload_pathways_workload_arguments.add_argument(
 workload_pathways_workload_arguments.add_argument(
     '--proxy-server-image',
     type=str,
-    default='gcr.io/cloud-tpu-v2-images/pathways/pathways-demo:proxy_server',
+    default='us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest',
     help='Please provide the proxy server image for Pathways.',
 )
 workload_pathways_workload_arguments.add_argument(
     '--server-image',
     type=str,
-    default='gcr.io/cloud-tpu-v2-images/pathways/pathways-demo:server',
+    default='us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest',
     help='Please provide the server image for Pathways.',
 )
 workload_pathways_workload_arguments.add_argument(


### PR DESCRIPTION
Our images have been migrated to Artifact registry. This is the current source of truth for good pathways images.
