### PR TITLE
Move all clusters to be RAPID clusters, and verify them using valid_v…

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -2597,7 +2597,7 @@ def run_gke_cluster_create_command(
       ' --total-min-nodes 1 --total-max-nodes 1000'
       f' --num-nodes {args.default_pool_cpu_num_nodes}'
       f' {args.custom_cluster_arguments}'
-      f' --release-channel rapid'
+      ' --release-channel rapid'
   )
 
   if system.accelerator_type == AcceleratorType['GPU']:
@@ -2606,10 +2606,7 @@ def run_gke_cluster_create_command(
         ' --enable-multi-networking --no-enable-autoupgrade'
     )
   else:
-    command += (
-        ' --location-policy=BALANCED'
-        ' --scopes=storage-full,gke-default'
-    )
+    command += ' --location-policy=BALANCED --scopes=storage-full,gke-default'
 
     if args.enable_pathways:
       command += (
@@ -4054,7 +4051,8 @@ def get_gke_server_config(args) -> tuple[int, GkeServerConfig | None]:
       ' --format="value(channels.defaultVersion)"'
   )
   valid_versions_cmd = (
-      base_command  + ' --flatten="channels" --filter="channels.channel=RAPID"'
+      base_command
+      + ' --flatten="channels" --filter="channels.channel=RAPID"'
       ' --format="value(channels.validVersions)"'
   )
   base_command_description = 'Determine server supported GKE versions for'
@@ -4110,9 +4108,7 @@ def get_gke_control_plane_version(
   else:
     master_gke_version = gke_server_config.default_rapid_gke_version
 
-  is_valid_version = (
-      master_gke_version in gke_server_config.valid_versions
-  )
+  is_valid_version = master_gke_version in gke_server_config.valid_versions
 
   if not is_valid_version:
     xpk_print(

--- a/xpk.py
+++ b/xpk.py
@@ -4064,7 +4064,7 @@ def get_gke_server_config(args) -> tuple[int, GkeServerConfig | None]:
       ),
       (
           valid_versions_cmd,
-          base_command_description + 'valid master versions',
+          base_command_description + 'valid versions',
       ),
   ]
   command_outputs = []
@@ -4112,8 +4112,8 @@ def get_gke_control_plane_version(
 
   if not is_valid_version:
     xpk_print(
-        f'Planned GKE Version: {master_gke_version}\n Valid Versions'
-        f' Versions:\n{gke_server_config.valid_versions}\nRecommended GKE'
+        f'Planned GKE Version: {master_gke_version}\n Valid Versions:'
+        f'\n{gke_server_config.valid_versions}\nRecommended / Default GKE'
         f' Version: {gke_server_config.default_rapid_gke_version}'
     )
     xpk_print(


### PR DESCRIPTION
…ersions correctly

## Fixes / Features
- Previous was using the non-release version clusters verification list when creating rapid gke clusters.
- Moved GPU clusters to also be rapid based for consistency.

## Testing / Documentation
Create a cluster with the default GKE version: success
Create an additional node pool with default GKE version: success
Specify a GKE version that is valid: success
Specify a GKE version that is invalid: failed correctly

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
