### PR TITLE
Add a check and update existing Pathways clusters to use CloudDNS.

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -3330,13 +3330,13 @@ def create_cluster_if_necessary(
     )
 
 
-def is_cluster_using_clouddns(args) -> int:
+def is_cluster_using_clouddns(args) -> bool:
   """Checks if cluster is using CloudDNS.
   Args:
     args: user provided arguments for running the command.
 
   Returns:
-    0 if cluster is using CloudDNS and 1 otherwise.
+    True if cluster is using CloudDNS and False otherwise.
   """
   command = (
       f'gcloud container clusters describe {args.cluster}'
@@ -3353,8 +3353,8 @@ def is_cluster_using_clouddns(args) -> int:
   cloud_dns_matches = int(cloud_dns_matches)
   if cloud_dns_matches > 0:
     xpk_print('Cloud DNS is enabled on the cluster, no update needed.')
-    return 0
-  return 1
+    return True
+  return False
 
 
 def update_cluster_with_clouddns_if_necessary(args) -> int:
@@ -3364,7 +3364,7 @@ def update_cluster_with_clouddns_if_necessary(args) -> int:
     args: user provided arguments for running the command.
 
   Returns:
-    0 if successful and 1 otherwise.
+    0 if successful and error code otherwise.
   """
   all_clusters, return_code = get_all_clusters_programmatic(args)
   if return_code > 0:
@@ -3372,7 +3372,7 @@ def update_cluster_with_clouddns_if_necessary(args) -> int:
     return 1
   if args.cluster in all_clusters:
     # If cluster is already using clouddns, no update necessary!
-    if is_cluster_using_clouddns(args) == 0:
+    if is_cluster_using_clouddns(args):
       return 0
     cluster_update_return_code = update_cluster_with_clouddns(args)
     if cluster_update_return_code > 0:

--- a/xpk.py
+++ b/xpk.py
@@ -2612,9 +2612,9 @@ def run_gke_cluster_create_command(
       command += (
           ' --enable-ip-alias'
           f' --create-subnetwork name={args.cluster}-subnetwork'
-          # ' --cluster-dns=clouddns'
-          # ' --cluster-dns-scope=vpc'
-          # f' --cluster-dns-domain={args.cluster}-domain'
+          ' --cluster-dns=clouddns'
+          ' --cluster-dns-scope=vpc'
+          f' --cluster-dns-domain={args.cluster}-domain'
       )
 
   return_code = run_command_with_updates(command, 'GKE Cluster Create', args)
@@ -2623,8 +2623,8 @@ def run_gke_cluster_create_command(
     return 1
   return 0
 
-def run_gke_pathways_cluster_update_command(
-    args) -> int:
+
+def run_gke_pathways_cluster_update_command(args) -> int:
   """Run the Pathways cluster update command for existing clusters.
 
   Args:
@@ -2642,11 +2642,14 @@ def run_gke_pathways_cluster_update_command(
       f' --cluster-dns-domain={args.cluster}-domain'
       ' --quiet'
   )
-  return_code = run_command_with_updates(command, 'Pathways Cluster Update to enable Cloud DNS', args)
+  return_code = run_command_with_updates(
+      command, 'Pathways Cluster Update to enable Cloud DNS', args
+  )
   if return_code != 0:
     xpk_print(f'Pathways Cluster Update request returned ERROR {return_code}')
     return 1
   return 0
+
 
 def run_node_pool_upgrade_command(args) -> int:
   """Upgrade Pathways nodepools to use CloudDNS.
@@ -2658,7 +2661,7 @@ def run_node_pool_upgrade_command(args) -> int:
     0 if successful and 1 otherwise.
   """
   existing_node_pool_names, return_code = get_all_nodepools_programmatic(args)
-  print(existing_node_pool_names) # REMOVE
+  print(existing_node_pool_names)  # REMOVE
   if return_code != 0:
     xpk_print('Listing all node pools failed!')
     return return_code
@@ -2666,7 +2669,7 @@ def run_node_pool_upgrade_command(args) -> int:
   # Batch execution to upgrade Pathways node pools simultaneously
   commands = []
   task_names = []
-  for node_pool_name in existing_node_pool_names:  
+  for node_pool_name in existing_node_pool_names:
     commands.append(
         'gcloud container clusters upgrade'
         f' {args.cluster} --project={args.project}'
@@ -2674,21 +2677,16 @@ def run_node_pool_upgrade_command(args) -> int:
         f' --node-pool={node_pool_name}'
         ' --quiet'
     )
-    task_names.append(
-        f'Update node pool {node_pool_name} to use CloudDNS.'
-    )
+    task_names.append(f'Update node pool {node_pool_name} to use CloudDNS.')
 
   for i, command in enumerate(commands):
     xpk_print(f'To complete {task_names[i]} we are executing {command}')
   max_return_code = run_commands(
-      commands,
-      'Update node pools to use CloudDNS',
-      task_names
+      commands, 'Update node pools to use CloudDNS', task_names
   )
   if max_return_code != 0:
     xpk_print(
-        'Update node pools to use CloudDNS returned ERROR:'
-        f' {max_return_code}'
+        f'Update node pools to use CloudDNS returned ERROR: {max_return_code}'
     )
     return max_return_code
   return 0
@@ -3300,14 +3298,12 @@ def create_cluster_if_necessary(
         args, gke_control_plane_version, system
     )
 
-def update_pathways_cluster_if_necessary(
-    args, system: SystemCharacteristics
-) -> int:
+
+def update_pathways_cluster_if_necessary(args) -> int:
   """Updates a Pathways cluster to use CloudDNS.
 
   Args:
     args: user provided arguments for running the command.
-    system: system characteristics.
 
   Returns:
     0 if successful and 1 otherwise.
@@ -3326,8 +3322,7 @@ def update_pathways_cluster_if_necessary(
       xpk_print('Updating Pathways nodepools to use CloudDNS failed!')
       return node_pool_update_code
   return 0
-    
-      
+
 
 def get_nodepool_zone(args, nodepool_name) -> tuple[int, str]:
   """Return zone in which nodepool exists in the cluster.
@@ -4350,7 +4345,7 @@ def cluster_create(args) -> None:
     xpk_exit(create_cluster_command_code)
 
   if args.enable_pathways:
-    update_cluster_command_code = update_pathways_cluster_if_necessary(args, system)
+    update_cluster_command_code = update_pathways_cluster_if_necessary(args)
     if update_cluster_command_code != 0:
       xpk_exit(update_cluster_command_code)
 


### PR DESCRIPTION
## Fixes / Features
- Update existing Pathways clusters to use CloudDNS without user intervention.
- This would avoid DNS resolution failures on existing Pathways clusters.
- Add a check to find if the cluster is using CloudDNS or not and upgrade automatically, as needed. 
- Upgrade reflects after 3 steps:
- - Step 1: Update cluster dns to use cloud dns
- - Step 2: Update GKE control plane version
- - Step 3: Update nodepools, which recreates nodes.

## Testing / Documentation
1. Upgrade existing cluster during the first "cluster create-pathways".
2. Upgrade existing cluster during the first "workload create-pathways".
3. No extra steps needed from the user

- [ y] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
