### PR TITLE
Add logic to fail Pathways jobs on user code errors.

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -62,7 +62,7 @@ jobs:
     - name: Wait for workload completion and confirm it succeeded
       run: python3 xpk.py workload list --cluster $TPU_CLUSTER_NAME --zone=us-central2-b --wait-for-job-completion $WORKLOAD_NAME --timeout 300
     - name: Run a Pathways workload on Ubuntu base image
-      run: python xpk.py workload create-pathways --cluster $TPU_CLUSTER_NAME --workload $PATHWAYS_WORKLOAD_NAME --docker-image='marketplace.gcr.io/google/ubuntu2004' --tpu-type=v4-8 --num-slices=2 --zone=us-central2-b --command "bash test.sh" 
+      run: python xpk.py workload create-pathways --cluster $TPU_CLUSTER_NAME --workload $PATHWAYS_WORKLOAD_NAME --docker-image='marketplace.gcr.io/google/ubuntu2004' --tpu-type=v4-8 --num-slices=2 --zone=us-central2-b --command "echo \"Hello world from a test script! \"" 
     - name: Wait for Pathways workload completion and confirm it succeeded
       run: python3 xpk.py workload list --cluster $TPU_CLUSTER_NAME --zone=us-central2-b --wait-for-job-completion $PATHWAYS_WORKLOAD_NAME --timeout 300
     - name: List out the workloads on the cluster

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -102,7 +102,7 @@ jobs:
     - name: Create test script to execute in workloads
       run: echo -e '#!/bin/bash \n echo "Hello world from a test script!"' > test.sh
     - name: Run a Pathways workload on Ubuntu base image
-      run: python xpk.py workload create-pathways --cluster $PATHWAYS_TPU_CLUSTER_NAME --workload $PATHWAYS_WORKLOAD_NAME --docker-image='marketplace.gcr.io/google/ubuntu2004' --tpu-type=v4-8 --num-slices=2 --zone=us-central2-b --command "bash test.sh"
+      run: python xpk.py workload create-pathways --cluster $PATHWAYS_TPU_CLUSTER_NAME --workload $PATHWAYS_WORKLOAD_NAME --docker-image='marketplace.gcr.io/google/ubuntu2004' --tpu-type=v4-8 --num-slices=2 --zone=us-central2-b --command "echo \"Hello world from a test script! \""
     - name: Wait for Pathways workload completion and confirm it succeeded
       run: python3 xpk.py workload list --cluster $PATHWAYS_TPU_CLUSTER_NAME --zone=us-central2-b --wait-for-job-completion $PATHWAYS_WORKLOAD_NAME --timeout 300
     - name: Delete the Pathways workload on the cluster

--- a/xpk.py
+++ b/xpk.py
@@ -7236,7 +7236,8 @@ def add_shared_workload_create_optional_arguments(args_parsers):
             'Adding this argument will return user failures back to the jobset'
             ' manager allowing restarts on user code when --max-restarts is set'
             ' greater than 0. By default, this is not enabled, and workloads'
-            ' will not restart from user code failures.'
+            ' will not restart from user code failures. This is enabled by'
+            ' default on Pathways workloads.'
         ),
     )
     custom_parser.add_argument(

--- a/xpk.py
+++ b/xpk.py
@@ -5030,7 +5030,11 @@ def get_main_container(args, system, docker_image, resource_type) -> str:
     )
 
   xpk_return_user_exit_code = ''
-  if not args.use_pathways and args.restart_on_user_code_failure:
+  # Always report user code failures back to JobSet.
+  if args.use_pathways:
+    args.restart_on_user_code_failure = True
+
+  if args.restart_on_user_code_failure:
     if int(args.max_restarts) <= 0:
       xpk_print(
           f'Warning: --max-restarts, is set to {args.max_restarts}. Will not'
@@ -7217,6 +7221,16 @@ def add_shared_workload_create_optional_arguments(args_parsers):
         ),
     )
     custom_parser.add_argument(
+        '--restart-on-user-code-failure',
+        action='store_true',
+        help=(
+            'Adding this argument will return user failures back to the jobset'
+            ' manager allowing restarts on user code when --max-restarts is set'
+            ' greater than 0. By default, this is not enabled, and workloads'
+            ' will not restart from user code failures.'
+        ),
+    )
+    custom_parser.add_argument(
         '--headless',
         action='store_true',
         help=(
@@ -7823,16 +7837,6 @@ workload_create_parser_optional_arguments.add_argument(
         'Add this argument to deploy a sidecar container that will '
         'read the stack traces collected in /tmp/debugging directory '
         'and forward them to Cloud Logging for TPU workloads.'
-    ),
-)
-workload_create_parser_optional_arguments.add_argument(
-    '--restart-on-user-code-failure',
-    action='store_true',
-    help=(
-        'Adding this argument will return user failures back to the jobset'
-        ' manager allowing restarts on user code when --max-restarts is set'
-        ' greater than 0. By default, this is not enabled, and workloads will'
-        ' not restart from user code failures.'
     ),
 )
 


### PR DESCRIPTION
## Fixes / Features
- Set "--restart-on-user-code-failure" to fail JobSet on user code errors, as default for Pathways jobs. Note that max_restarts is 0 by default (unless altered for suspend/resume use-cases.)
- Pool the many Pathways workload create checks and setting into one function called ensure_pathways_workload_prerequisites()

## Testing / Documentation
Tested locally with changes
<img width="1540" alt="Screenshot 2024-06-05 at 11 49 05 AM" src="https://github.com/google/xpk/assets/8955691/3745e48f-a6dd-4c19-b773-4e3052bb1dfe">

Here roshanin-pw-test3 is correct and roshanin-pw-test4 contains a typo in user code.


- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
