### PR TITLE
Update XPK to support topology-aware scheduler for GPU workloads.

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -161,23 +161,10 @@ spec:
               labels:
                 xpk.google.com/workload: {args.workload}
             spec:
-              schedulerName: {args.scheduler}
-              restartPolicy: Never
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: cloud.google.com/gke-accelerator
-                        operator: Exists
-                      - key: cloud.google.com/gke-nodepool
-                        operator: In
-                        values: [{node_pool_name}]
-              nodeSelector:
-                {accelerator_label}
-                {machine_label}
-                {autoprovisioning_args}
+              schedulingGates:
+              - name: "gke.io/topology-aware-auto-{args.workload}"
               priorityClassName: {args.priority}
+              restartPolicy: Never
               hostNetwork: true
               dnsPolicy: ClusterFirstWithHostNet
               terminationGracePeriodSeconds: {args.termination_grace_period_seconds}
@@ -5971,7 +5958,7 @@ def get_gpu_rxdm_image(system: SystemCharacteristics) -> str:
                 image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd-dev:v2.0.9"""
   elif system.device_type == h100_mega_device_type:
     gpu_rxdm_image = """- name: fastrak-daemon
-                image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.6-sctp"""
+                image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.8"""
   return gpu_rxdm_image
 
 

--- a/xpk.py
+++ b/xpk.py
@@ -5922,9 +5922,9 @@ def get_autoprovisioning_node_selector_args(args) -> tuple[str, int]:
   return node_selector_args, return_code
 
 
-def get_gpu_scheduler(args,
-                      system: SystemCharacteristics,
-                      autoprovisioning_args: str) -> str:
+def get_gpu_scheduler(
+    args, system: SystemCharacteristics, autoprovisioning_args: str
+) -> str:
   """Get gpu scheduler configuration.
 
   Args:
@@ -5934,20 +5934,22 @@ def get_gpu_scheduler(args,
 
   Returns:
     str: yaml containing gpu scheduler configuration
-  """ 
+  """
   if args.scheduler == 'gke.io/topology-aware-auto':
     gpu_scheduler = f"""schedulingGates:
               - name: "{args.scheduler}-{args.workload}"
               """
   else:
     gpu_scheduler = gpu_scheduler_yaml.format(
-      scheduler_name=args.scheduler,
-      accelerator_label=create_accelerator_label(system.accelerator_type, system),
-      machine_label=create_machine_label(system.accelerator_type, system),
-      node_pool_name=f'{args.cluster}-np-0',
-      autoprovisioning_args=autoprovisioning_args
+        scheduler_name=args.scheduler,
+        accelerator_label=create_accelerator_label(
+            system.accelerator_type, system
+        ),
+        machine_label=create_machine_label(system.accelerator_type, system),
+        node_pool_name=f'{args.cluster}-np-0',
+        autoprovisioning_args=autoprovisioning_args,
     )
-  
+
   return gpu_scheduler
 
 
@@ -7854,11 +7856,11 @@ workload_create_parser_optional_arguments.add_argument(
     type=str,
     default='default-scheduler',
     help=(
-        'Which scheduler you want to use. Defaults to `default-scheduler`. '
-        'If your cluster is configured for high throughput scheduling, you might '
-        'want to use `gke.io/high-throughput-scheduler`.'
-        'If your cluster is configured for topology-aware scheduling, you might '
-        'want to use `gke.io/topology-aware-auto`.'
+        'Which scheduler you want to use. Defaults to `default-scheduler`. If'
+        ' your cluster is configured for high throughput scheduling, you might'
+        ' want to use `gke.io/high-throughput-scheduler`.If your cluster is'
+        ' configured for topology-aware scheduling, you might want to use'
+        ' `gke.io/topology-aware-auto`.'
     ),
 )
 workload_create_parser_optional_arguments.add_argument(


### PR DESCRIPTION
## Fixes / Features
- Support topology-aware scheduler for GPU workloads

## Testing / Documentation
Manually tested two cases:
1. Use topology-aware scheduler for running MaxText at a single node on A3+.
2. Use default-scheduler for running MaxText at a single node on A3+.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
