### PR TITLE
Allow SIGTERM error code to be returned from XPK

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -5055,7 +5055,25 @@ def get_main_container(args, system, docker_image, resource_type) -> str:
                 - bash
                 - -c
                 - |
-                  echo XPK Start: $(date) ; _sigterm() ( kill -SIGTERM $! 2>/dev/null;); trap _sigterm SIGTERM;{gsutil_test_command}({command}) & PID=$!; while kill -0 $PID 2>/dev/null; do sleep 5; done; wait $PID; EXIT_CODE=$? ; {xpk_internal_commands} echo XPK End: $(date); echo EXIT_CODE=$EXIT_CODE; {tpu_stacktrace_terminate_command} {gpu_workload_terminate_command} {xpk_return_user_exit_code}
+                  echo XPK Start: $(date);
+                  _sigterm() (kill -SIGTERM $! 2>/dev/null;);
+                  trap _sigterm SIGTERM;
+                  {gsutil_test_command}
+                  ({command}) & PID=$!;
+                  while kill -0 $PID 2>/dev/null;
+                      do sleep 5;
+                  done;
+                  wait $PID;
+                  EXIT_CODE=$?;
+                  {xpk_internal_commands}
+                  echo XPK End: $(date);
+                  echo EXIT_CODE=$EXIT_CODE;
+                  {tpu_stacktrace_terminate_command}
+                  {gpu_workload_terminate_command}
+                  if [ "$EXIT_CODE" = 143 ]; then
+                    exit $EXIT_CODE
+                  fi
+                  {xpk_return_user_exit_code}
                 resources:
                   limits:
                     {resources}


### PR DESCRIPTION
When SIGTERM is caught by XPK for graceful migration, we hold to the exit code and return 0. However in the SIGTERM case, we should always propagate the error code (143 / SIGTERM) so that if the jobset has --max-restarts set > 0, the job can properly restart.

## Fixes / Features
- Allows XPK to restart when we have a sigterm.
-

## Testing / Documentation
Caught a sigterm properly in XPK and the jobset restarted.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
