### PR TITLE
Allow debug_dump_gcs to be specified with other XLA_FLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ environment from a file. Usage is the same as Docker's
     ```
 
 * Workload create accepts a --debug-dump-gcs flag which is a path to GCS bucket.
-Passing this flag sets the XLA_FLAGS='--xla_dump_to=/tmp/xla_dump/' and uploads
+Passing this flag adds '--xla_dump_to=/tmp/xla_dump/' to XLA_FLAGS and uploads
 hlo dumps to the specified GCS bucket for each worker.
 
 # Integration Test Workflows

--- a/xpk.py
+++ b/xpk.py
@@ -2058,13 +2058,14 @@ def parse_env_config(args, tensorboard_config, system: SystemCharacteristics):
 
   if not args.use_pathways:
     if args.debug_dump_gcs:
-      if 'XLA_FLAGS' in env:
+      if 'XLA_FLAGS' in env and '--xla_dump_to=' in env['XLA_FLAGS']:
         raise ValueError(
-            'Conflict: XLA_FLAGS defined in both --debug_dump_gcs '
-            'and environment file. Please choose one way to define '
-            'XLA_FLAGS.'
+            'Conflict: --xla_dump_to flag defined by both --debug_dump_gcs '
+            'and XLA_FLAGS in container environment. Please choose one way to '
+            'define.'
         )
-      env['XLA_FLAGS'] = '--xla_dump_to=/tmp/xla_dump/'
+      xla_flags = env.get('XLA_FLAGS', '')
+      env['XLA_FLAGS'] = xla_flags + ' --xla_dump_to=/tmp/xla_dump/'
 
     if tensorboard_config:
       env['UPLOAD_DATA_TO_TENSORBOARD'] = True


### PR DESCRIPTION
## Fixes / Features
- `debug-dump-gcs` doesn't need to be exclusive with environment-specified `XLA_FLAGS`.

## Testing / Documentation
Testing details:

- `xpk workload create ... --debug-dump-gcs gs://foo/bar --env XLA_FLAGS=--xla_dump_to=/foo/bar` => `ValueError: Conflict: --xla_dump_to flag defined by both --debug_dump_gcs and XLA_FLAGS in container environment. Please choose one way to define.`
- `xpk workload create ... --debug-dump-gcs gs://foo/bar --env XLA_FLAGS=--xla_foo=bar` => workload created with XLA_FLAGS `--xla_foo=bar --xla_dump_to=/tmp/xla_dump/`
- `xpk workload create ... --debug-dump-gcs gs://foo/bar` => workload created with XLA_FLAGS ` --xla_dump_to=/tmp/xla_dump/` (note the leading space, but XLA has no problem parsing).

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
