### PR TITLE
Update RxDM image version from v1.0.8 to v1.0.9.

### DIFF
--- a/xpk.py
+++ b/xpk.py
@@ -6031,7 +6031,7 @@ def get_gpu_rxdm_image(system: SystemCharacteristics) -> str:
                 image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd-dev:v2.0.9"""
   elif system.device_type == h100_mega_device_type:
     gpu_rxdm_image = """- name: fastrak-daemon
-                image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.8"""
+                image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.9"""
   return gpu_rxdm_image
 
 


### PR DESCRIPTION
## Fixes / Features
- Update RxDM image version for A3 Mega with the network release of 6/27. The network release of 6/27 can be found in this doc: https://docs.google.com/document/d/1D5umT4-WDuNnYf3ieQ5SfLdmvGRPBQGLB662udzwz8I/edit?tab=t.0#bookmark=id.tezgud50glwu.

## Testing / Documentation
Manual test passed with the changes.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
