### PR TITLE
Enabling Workload Identity and GCSFuse driver flags added.

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -45,6 +45,7 @@ source $VENV_DIR/bin/activate
 
 ```shell
 git clone https://github.com/google/xpk.git
+cd xpk
 pip install .[dev]
 ```
 

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -90,7 +90,7 @@ def cluster_create(args) -> None:
     xpk_exit(create_cluster_command_code)
 
   # Enable WorkloadIdentity if not enabled already.
-  if args.enable_workload_identity or args.enable_gcsfuse_driver:
+  if args.enable_workload_identity or args.enable_gcsfuse_csi_driver:
     update_cluster_command_code = (
         update_cluster_with_workload_identity_if_necessary(args)
     )
@@ -98,7 +98,7 @@ def cluster_create(args) -> None:
       xpk_exit(update_cluster_command_code)
 
   # Enable GCSFuse CSI Driver if not enabled already.
-  if args.enable_gcsfuse_driver:
+  if args.enable_gcsfuse_csi_driver:
     update_cluster_command_code = (
         update_cluster_with_gcsfuse_driver_if_necessary(args)
     )
@@ -491,7 +491,7 @@ def run_gke_cluster_create_command(
           f' --cluster-dns-domain={args.cluster}-domain'
       )
 
-  if args.enable_workload_identity or args.enable_gcsfuse_driver:
+  if args.enable_workload_identity or args.enable_gcsfuse_csi_driver:
     command += f' --workload-pool={args.project}.svc.id.goog'
 
   if args.enable_gcsfuse_csi_driver:

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -36,6 +36,8 @@ from ..core.core import (
     set_jobset_on_cluster,
     set_up_cluster_network_for_gpu,
     update_cluster_with_clouddns_if_necessary,
+    update_cluster_with_workload_identity_if_necessary,
+    update_cluster_with_gcsfuse_driver_if_necessary,
     zone_to_region,
 )
 from ..core.kueue import (
@@ -86,6 +88,22 @@ def cluster_create(args) -> None:
   )
   if create_cluster_command_code != 0:
     xpk_exit(create_cluster_command_code)
+
+  # Enable WorkloadIdentity if not enabled already.
+  if args.enable_workload_identity or args.enable_gcsfuse_driver:
+    update_cluster_command_code = (
+        update_cluster_with_workload_identity_if_necessary(args)
+    )
+    if update_cluster_command_code != 0:
+      xpk_exit(update_cluster_command_code)
+
+  # Enable GCSFuse CSI Driver if not enabled already.
+  if args.enable_gcsfuse_driver:
+    update_cluster_command_code = (
+        update_cluster_with_gcsfuse_driver_if_necessary(args)
+    )
+    if update_cluster_command_code != 0:
+      xpk_exit(update_cluster_command_code)
 
   # Update Pathways clusters with CloudDNS if not enabled already.
   if args.enable_pathways:
@@ -472,6 +490,12 @@ def run_gke_cluster_create_command(
           ' --cluster-dns-scope=vpc'
           f' --cluster-dns-domain={args.cluster}-domain'
       )
+
+  if args.enable_workload_identity or args.enable_gcsfuse_driver:
+    command += f' --workload-pool={args.project}.svc.id.goog'
+
+  if args.enable_gcsfuse_csi_driver:
+    command += ' --addons GcsFuseCsiDriver'
 
   return_code = run_command_with_updates(command, 'GKE Cluster Create', args)
   if return_code != 0:

--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -360,6 +360,61 @@ def update_gke_cluster_with_clouddns(args) -> int:
   return 0
 
 
+def update_gke_cluster_with_workload_identity_enabled(args) -> int:
+  """Run the GKE cluster update command for existing cluster and enable Workload Identity Federation.
+  Args:
+    args: user provided arguments for running the command.
+  Returns:
+    0 if successful and 1 otherwise.
+  """
+  command = (
+      'gcloud container clusters update'
+      f' {args.cluster} --project={args.project}'
+      f' --region={zone_to_region(args.zone)}'
+      f' --workload-pool={args.project}.svc.id.goog'
+      ' --quiet'
+  )
+  xpk_print(
+      'Updating GKE cluster to enable Workload Identity Federation, may take a'
+      ' while!'
+  )
+  return_code = run_command_with_updates(
+      command, 'GKE Cluster Update to enable Workload Identity Federation', args
+  )
+  if return_code != 0:
+    xpk_print(f'GKE Cluster Update request returned ERROR {return_code}')
+    return 1
+  return 0
+
+
+def update_gke_cluster_with_gcsfuse_driver_enabled(args) -> int:
+  """Run the GKE cluster update command for existing cluster and enable GCSFuse CSI driver.
+  Args:
+    args: user provided arguments for running the command.
+  Returns:
+    0 if successful and 1 otherwise.
+  """
+  command = (
+      'gcloud container clusters update'
+      f' {args.cluster} --project={args.project}'
+      f' --region={zone_to_region(args.zone)}'
+      ' --addons GcsFuseCsiDriver'
+      ' --quiet'
+  )
+  xpk_utils.xpk_print(
+      'Updating GKE cluster to enable GCSFuse CSI driver, may take a while!'
+  )
+  return_code = run_command_with_updates(
+      command, 'GKE Cluster Update to enable GCSFuse CSI driver', args
+  )
+  if return_code != 0:
+    xpk_utils.xpk_print(
+        f'GKE Cluster Update request returned ERROR {return_code}'
+    )
+    return 1
+  return 0
+
+
 def upgrade_gke_control_plane_version(args, default_rapid_gke_version) -> int:
   """Upgrade GKE cluster's control plane version before updating nodepools to use CloudDNS.
 
@@ -1045,6 +1100,59 @@ def is_cluster_using_clouddns(args) -> bool:
   return False
 
 
+def is_workload_identity_enabled_on_cluster(args) -> bool:
+  """Checks if Workload Identity Federation is enabled on the cluster.
+  Args:
+    args: user provided arguments for running the command.
+  Returns:
+    True if Workload Identity Federation is enabled on the cluster and False otherwise.
+  """
+  command = (
+      f'gcloud container clusters describe {args.cluster}'
+      f' --project={args.project} --region={zone_to_region(args.zone)}'
+      ' --format="value(workloadIdentityConfig.workloadPool)"'
+  )
+  return_code, workload_pool = run_command_for_value(
+      command,
+      'Checks if Workload Identity Federation is enabled in cluster describe.',
+      args,
+  )
+  if return_code != 0:
+    xpk_exit(return_code)
+  if workload_pool == f'{args.project}.svc.id.goog':
+    xpk_print(
+        'Workload Identity Federation is enabled on the cluster, no update'
+        ' needed.'
+    )
+    return True
+  return False
+
+
+def is_gcsfuse_driver_enabled_on_cluster(args) -> bool:
+  """Checks if GCSFuse CSI driver is enabled on the cluster.
+  Args:
+    args: user provided arguments for running the command.
+  Returns:
+    True if GCSFuse CSI driver is enabled on the cluster and False otherwise.
+  """
+  command = (
+      f'gcloud container clusters describe {args.cluster}'
+      f' --project={args.project} --region={zone_to_region(args.zone)}'
+      ' --format="value(addonsConfig.gcsFuseCsiDriverConfig.enabled)"'
+  )
+  return_code, gcsfuse_driver_enabled = run_command_for_value(
+      command,
+      'Checks if GCSFuse CSI driver is enabled in cluster describe.',
+      args,
+  )
+  if return_code != 0:
+    xpk_exit(return_code)
+  if gcsfuse_driver_enabled.lower() == 'true':
+    xpk_print('GCSFuse CSI driver is enabled on the cluster, no update needed.')
+    return True
+  return False
+
+
 def update_cluster_with_clouddns_if_necessary(args) -> int:
   """Updates a GKE cluster to use CloudDNS, if not enabled already.
 
@@ -1088,6 +1196,48 @@ def update_cluster_with_clouddns_if_necessary(args) -> int:
   return 0
 
 
+def update_cluster_with_workload_identity_if_necessary(args) -> int:
+  """Updates a GKE cluster to enable Workload Identity Federation, if not enabled already.
+  Args:
+    args: user provided arguments for running the command.
+  Returns:
+    0 if successful and error code otherwise.
+  """
+
+  if is_workload_identity_enabled_on_cluster(args):
+    return 0
+  cluster_update_return_code = (
+      update_gke_cluster_with_workload_identity_enabled(args)
+  )
+  if cluster_update_return_code > 0:
+    xpk_print(
+        'Updating GKE cluster to enable Workload Identity Federation failed!'
+    )
+    return cluster_update_return_code
+
+  return 0
+
+
+def update_cluster_with_gcsfuse_driver_if_necessary(args) -> int:
+  """Updates a GKE cluster to enable GCSFuse CSI driver, if not enabled already.
+  Args:
+    args: user provided arguments for running the command.
+  Returns:
+    0 if successful and error code otherwise.
+  """
+
+  if is_gcsfuse_driver_enabled_on_cluster(args):
+    return 0
+  cluster_update_return_code = update_gke_cluster_with_gcsfuse_driver_enabled(
+      args
+  )
+  if cluster_update_return_code > 0:
+    xpk_print('Updating GKE cluster to enable GCSFuse CSI driver failed!')
+    return cluster_update_return_code
+
+  return 0
+
+
 def get_nodepool_zone(args, nodepool_name) -> tuple[int, str]:
   """Return zone in which nodepool exists in the cluster.
 
@@ -1113,6 +1263,34 @@ def get_nodepool_zone(args, nodepool_name) -> tuple[int, str]:
     return 1, None
 
   return 0, nodepool_zone.strip()
+
+
+def get_nodepool_workload_metadata_mode(args, nodepool_name) -> tuple[int, str]:
+  """Return Workload Identity metadata mode of the nodepool.
+  Args:
+    args: user provided arguments for running the command.
+    nodepool_name: name of nodepool.
+  Returns:
+    Tuple of int, str where
+    int is the return code - 0 if successful, 1 otherwise.
+    str is the workload metadata mode of nodepool.
+  """
+  command = (
+      f'gcloud beta container node-pools describe {nodepool_name}'
+      f' --cluster {args.cluster} --project={args.project}'
+      f' --region={zone_to_region(args.zone)} --format="value(config.workloadMetadataConfig.mode)"'
+  )
+  return_code, nodepool_WI_mode = run_command_for_value(
+      command, 'Get Node Pool Workload Identity Metadata Mode', args
+  )
+  if return_code != 0:
+    xpk_print(
+        'Get Node Pool Workload Identity Metadata Mode returned ERROR'
+        f' {return_code}'
+    )
+    return 1, None
+
+  return 0, nodepool_WI_mode.strip()
 
 
 def check_cluster_resources(args, system) -> tuple[bool, bool]:
@@ -1339,6 +1517,9 @@ def run_gke_node_pool_create_command(
   node_pools_to_remain = []
   delete_commands = []
   delete_task_names = []
+  node_pools_to_update_WI = []
+  update_WI_commands = []
+  update_WI_task_names = []
   if existing_node_pool_names:
     return_code, existing_node_pool_zone = get_nodepool_zone(
         args, existing_node_pool_names[0]
@@ -1374,6 +1555,36 @@ def run_gke_node_pool_create_command(
       else:
         node_pools_to_remain.append(node_pool_name)
 
+    # Workload Identity for existing nodepools
+    if args.enable_workload_identity or args.enable_gcsfuse_driver:
+      for node_pool_name in existing_node_pool_names:
+        if not node_pool_name in node_pools_to_delete:
+          # Check if workload identity is not already enabled:
+          return_code, existing_node_pool_medadata_mode = (
+              get_nodepool_workload_metadata_mode(args, node_pool_name)
+          )
+          if return_code != 0:
+            return 1
+
+          if (
+              existing_node_pool_zone
+              and existing_node_pool_medadata_mode != 'GKE_METADATA'
+          ):
+            command = (
+                'gcloud container node-pools update'
+                f' {node_pool_name} --cluster={args.cluster}'
+                f' --zone={zone_to_region(args.zone)}'
+                f' --project={args.project} --quiet'
+                ' --workload-metadata=GKE_METADATA'
+            )
+            task = (
+                'Update nodepool with Workload Identity enabled'
+                f' {node_pool_name}'
+            )
+            update_WI_commands.append(command)
+            update_WI_task_names.append(task)
+            node_pools_to_update_WI.append(node_pool_name)
+
   # Deletion of nodepools should happen before attempting to create new nodepools for the case
   # when cluster is getting updated from 'x' device_type/gke_accelerator to 'y' device_type/gke_accelerator.
   # In that case, '{args.cluster}-np-i' nodepool will be re-created for 'y' device_type/gke_accelerator.
@@ -1405,6 +1616,35 @@ def run_gke_node_pool_create_command(
     if max_return_code != 0:
       xpk_print(f'Delete Nodepools returned ERROR {max_return_code}')
       return 1
+
+  # Enable Workload Identity on existing Nodepools
+  if update_WI_commands:
+    will_update_WI = True
+    if node_pools_to_update_WI and not args.force:
+      will_update_WI = get_user_input(
+          'Planning to enable Workload Identity Federation on'
+          f' {len(node_pools_to_update_WI)} existing node pools including'
+          f' {node_pools_to_update_WI}.This immediately enables Workload'
+          ' Identity Federation for GKE for any workloads running in the node'
+          ' pool. \nDo you wish to update: y (yes) / n (no):\n'
+      )
+    if not will_update_WI:
+      for i, command in enumerate(update_WI_commands):
+        xpk_print(
+            f'To complete {update_WI_task_names[i]} we are executing {command}'
+        )
+      max_return_code = run_commands(
+          update_WI_commands,
+          'Enable Workload Identity on existing Nodepools',
+          update_WI_task_names,
+          dry_run=args.dry_run,
+      )
+      if max_return_code != 0:
+        xpk_print(
+            'Enable Workload Identity on existing Nodepools returned ERROR'
+            f' {max_return_code}'
+        )
+        return 1
 
     # Update {args.cluster}-{_CLUSTER_RESOURCES_CONFIGMAP} ConfigMap to 'y': '0'
     # and remove 'x' from the ConfigMap when cluster is getting updated from
@@ -1484,6 +1724,9 @@ def run_gke_node_pool_create_command(
     elif system.accelerator_type == AcceleratorType['CPU']:
       command += f' --num-nodes={system.vms_per_slice}'
       command += ' --scopes=storage-full,gke-default'
+
+    if args.enable_workload_identity or args.enable_gcsfuse_driver:
+      command += ' --workload-metadata=GKE_METADATA'
 
     task = f'NodepoolCreate-{node_pool_name}'
     create_commands.append(command)

--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -1624,7 +1624,9 @@ def run_gke_node_pool_create_command(
           f' {len(node_pools_to_update_WI)} existing node pools including'
           f' {node_pools_to_update_WI}.This immediately enables Workload'
           ' Identity Federation for GKE for any workloads running in the node'
-          ' pool. \nDo you wish to update: y (yes) / n (no):\n'
+          ' pool. Also, xpk does not support disabling Workload Identity on'
+          ' clusters that have it enabled already \nDo you wish to update: y'
+          ' (yes) / n (no):\n'
       )
     if not will_update_WI:
       for i, command in enumerate(update_WI_commands):

--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -398,19 +398,17 @@ def update_gke_cluster_with_gcsfuse_driver_enabled(args) -> int:
       'gcloud container clusters update'
       f' {args.cluster} --project={args.project}'
       f' --region={zone_to_region(args.zone)}'
-      ' --addons GcsFuseCsiDriver'
+      ' --update-addons GcsFuseCsiDriver=ENABLED'
       ' --quiet'
   )
-  xpk_utils.xpk_print(
+  xpk_print(
       'Updating GKE cluster to enable GCSFuse CSI driver, may take a while!'
   )
   return_code = run_command_with_updates(
       command, 'GKE Cluster Update to enable GCSFuse CSI driver', args
   )
   if return_code != 0:
-    xpk_utils.xpk_print(
-        f'GKE Cluster Update request returned ERROR {return_code}'
-    )
+    xpk_print(f'GKE Cluster Update request returned ERROR {return_code}')
     return 1
   return 0
 
@@ -1556,7 +1554,7 @@ def run_gke_node_pool_create_command(
         node_pools_to_remain.append(node_pool_name)
 
     # Workload Identity for existing nodepools
-    if args.enable_workload_identity or args.enable_gcsfuse_driver:
+    if args.enable_workload_identity or args.enable_gcsfuse_csi_driver:
       for node_pool_name in existing_node_pool_names:
         if not node_pool_name in node_pools_to_delete:
           # Check if workload identity is not already enabled:
@@ -1725,7 +1723,7 @@ def run_gke_node_pool_create_command(
       command += f' --num-nodes={system.vms_per_slice}'
       command += ' --scopes=storage-full,gke-default'
 
-    if args.enable_workload_identity or args.enable_gcsfuse_driver:
+    if args.enable_workload_identity or args.enable_gcsfuse_csi_driver:
       command += ' --workload-metadata=GKE_METADATA'
 
     task = f'NodepoolCreate-{node_pool_name}'

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -449,6 +449,21 @@ def add_shared_cluster_create_optional_arguments(args_parsers):
             ' --custom-tpu-nodepool-arguments="--enable-ip-alias"'
         ),
     )
+    custom_parser.add_argument(
+        '--enable-workload-identity',
+        action='store_true',
+        help=(
+            'Enable Workload Identity Federation on the cluster and node-pools.'
+        ),
+    )
+    custom_parser.add_argument(
+        '--enable-gcsfuse-csi-driver',
+        action='store_true',
+        help=(
+            'Enable GSCFuse driver on the cluster. This enables Workload'
+            ' Identity Federation.'
+        ),
+    )
 
 
 def add_shared_cluster_create_tensorboard_arguments(args_parsers):


### PR DESCRIPTION
## Fixes / Features
- `--enable-workload-identity` flag implemented for `cluster create' command. It enables Workload Identity Federation on the cluster and node-pools.
- `--enable-gcsfuse-csi-driver` flag implemented for `cluster create' command. It enables GSCFuse driver on the cluster. This also enables Workload Identity Federation.'

## Testing / Documentation
Manual tests.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
